### PR TITLE
Fix abmiguity resolution for change in OffsetArrays.OffsetAxis

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,5 +10,5 @@ version = "1.1.0"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
-OffsetArrays = "1.0.2"
+OffsetArrays = "1.1.2"
 julia = "1.3"

--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -48,8 +48,8 @@ CircularArray(def::T, size) where T = CircularArray(fill(def, size))
 @inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Int64,Vararg{Int64}}) where T = _similar(arr,T,dims)
 # Ambiguity resolution with a type-pirating OffsetArrays method. See OffsetArrays issue #87.
 # Ambiguity is triggered in the case similar(arr) where arr.data::OffsetArray.
-using OffsetArrays: OffsetAxis
-@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{OffsetAxis, Vararg{OffsetAxis}}) where T = _similar(arr,T,dims)
+using OffsetArrays: OffsetAxisKnownLength
+@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{OffsetAxisKnownLength, Vararg{OffsetAxisKnownLength}}) where T = _similar(arr,T,dims)
 
 CircularVector(data::AbstractArray{T, 1}) where T = CircularVector{T}(data)
 CircularVector(def::T, size::Int) where T = CircularVector{T}(fill(def, size))


### PR DESCRIPTION
`similar(::CircularArray, ::Type, ::UnitRange)` broke with JuliaArrays/OffsetArrays.jl#126, because the meaning of `OffsetArrays.OffsetAxis` changed. The old `OffsetAxis` is now called `OffsetAxisKnownLength`.