### PR TITLE
Fix OffsetArrays ambiguity resolution again

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ version = "1.1.1"
 # It's listed as a dependency to allow a compat entry, since versions earlier
 # than OffsetArrays 1.3 would cause method ambiguities with this package,
 # which are triggered by similar(arr) when arr.data::OffsetArray.
-# See #3 and OffsetArrays#6.
+# See #3, #8 and OffsetArrays#6.
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -7,8 +7,13 @@ url = "https://github.com/Vexatos/CircularArrays.jl"
 version = "1.1.1"
 
 [deps]
+# The OffsetArrays dependency is not used.
+# It's listed as a dependency to allow a compat entry, since versions earlier
+# than OffsetArrays 1.3 would cause method ambiguities with this package,
+# which are triggered by similar(arr) when arr.data::OffsetArray.
+# See #3 and OffsetArrays#6.
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [compat]
-OffsetArrays = "1.1.2"
+OffsetArrays = "1.3"
 julia = "1.3"

--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -46,10 +46,6 @@ CircularArray(def::T, size) where T = CircularArray(fill(def, size))
 @inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Base.DimOrInd, Vararg{Base.DimOrInd}}) where T = _similar(arr,T,dims)
 # Ambiguity resolution with Base
 @inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Int64,Vararg{Int64}}) where T = _similar(arr,T,dims)
-# Ambiguity resolution with a type-pirating OffsetArrays method. See OffsetArrays issue #87.
-# Ambiguity is triggered in the case similar(arr) where arr.data::OffsetArray.
-using OffsetArrays: OffsetAxisKnownLength
-@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{OffsetAxisKnownLength, Vararg{OffsetAxisKnownLength}}) where T = _similar(arr,T,dims)
 
 CircularVector(data::AbstractArray{T, 1}) where T = CircularVector{T}(data)
 CircularVector(def::T, size::Int) where T = CircularVector{T}(fill(def, size))


### PR DESCRIPTION
Since JuliaArrays/OffsetArrays.jl#157, `OffsetArrays.OffsetAxisKnownLength == Base.DimOrInd`, so the ambiguity-resolving method from #1 overwrites the earlier `similar` method, triggering a warning. This simply removes the method, which is not needed anymore.
For this to work, `OffsetArrays` needs to be at version >=1.3, so I keep it as a dependency with a comment in `Project.toml` (comments in `Project.toml` are not preserved by `Pkg` operations unfortunately, but I think it's still better than no comment).
