### PR TITLE
Simplify indexing

### DIFF
--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -35,11 +35,15 @@ CircularArray(def::T, size) where T = CircularArray(fill(def, size))
     @inbounds getindex(arr.data, mod1(i, length(arr.data)))
 @inline Base.getindex(arr::CircularArray{T,N}, I::Vararg{<:Int,N}) where {T,N} =
     @inbounds getindex(arr.data, map(mod, I, axes(arr.data))...)
+@inline Base._getindex(::IndexLinear, arr::CircularArray{T,N}, I::Vararg{<:Int,N}) where {T,N} =
+    @inbounds Base._getindex(IndexLinear(), arr.data, map(mod, I, axes(arr.data))...)
 
 @inline Base.setindex!(arr::CircularArray, v, i::Int) =
     @inbounds setindex!(arr.data, v, mod1(i, length(arr.data)))
 @inline Base.setindex!(arr::CircularArray{T,N}, v, I::Vararg{<:Int,N}) where {T,N} =
     @inbounds setindex!(arr.data, v, map(mod, I, axes(arr.data))...)
+@inline Base._setindex!(::IndexLinear, arr::CircularArray{T,N}, v, I::Vararg{<:Int,N}) where {T,N} =
+    @inbounds Base._setindex!(IndexLinear(), arr.data, v, map(mod, I, axes(arr.data))...)
 
 @inline Base.size(arr::CircularArray) = size(arr.data)
 @inline Base.axes(arr::CircularArray) = axes(arr.data)

--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -32,12 +32,12 @@ CircularArray{T}(data::AbstractArray{T,N}) where {T,N} = CircularArray{T,N}(data
 CircularArray(def::T, size) where T = CircularArray(fill(def, size))
 
 @inline Base.getindex(arr::CircularArray, i::Integer) =
-    @inbounds getindex(arr.data, mod(i, eachindex(LinearIndices(arr.data))))
+    @inbounds getindex(arr.data, mod1(i, length(arr.data)))
 @inline Base.getindex(arr::CircularArray{T,N}, I::Vararg{<:Integer,N}) where {T,N} =
     @inbounds getindex(arr.data, map(mod, I, axes(arr.data))...)
 
 @inline Base.setindex!(arr::CircularArray, v, i::Integer) =
-    @inbounds setindex!(arr.data, v, mod(i, eachindex(LinearIndices(arr.data))))
+    @inbounds setindex!(arr.data, v, mod1(i, length(arr.data)))
 @inline Base.setindex!(arr::CircularArray{T,N}, v, I::Vararg{<:Integer,N}) where {T,N} =
     @inbounds setindex!(arr.data, v, map(mod, I, axes(arr.data))...)
 
@@ -47,8 +47,7 @@ Base.parent(arr::CircularArray) = arr.data
 
 @inline function Base.checkbounds(arr::CircularArray, I...)
     J = Base.to_indices(arr, I)
-    length(J) == 1 && return nothing
-    length(J) >= ndims(arr) && return nothing
+    (length(J) == 1 || length(J) >= ndims(arr)) && return nothing
     throw(BoundsError(arr, I))
 end
 

--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -27,18 +27,17 @@ Alias for [`CircularArray{T,1,A}`](@ref).
 """
 const CircularVector{T} = CircularArray{T, 1}
 
-@inline clamp_bounds(arr::CircularArray, I::Tuple{Vararg{Int}})::AbstractArray{Int, 1} = map(Base.splat(mod), zip(I, axes(arr.data)))
-
 CircularArray(data::AbstractArray{T,N}) where {T,N} = CircularArray{T,N}(data)
 CircularArray{T}(data::AbstractArray{T,N}) where {T,N} = CircularArray{T,N}(data)
 CircularArray(def::T, size) where T = CircularArray(fill(def, size))
 
-@inline Base.getindex(arr::CircularArray, i::Int) = @inbounds getindex(arr.data, mod(i, Base.axes1(arr.data)))
-@inline Base.setindex!(arr::CircularArray, v, i::Int) = @inbounds setindex!(arr.data, v, mod(i, Base.axes1(arr.data)))
-@inline Base.getindex(arr::CircularArray, I::Vararg{Int}) = @inbounds getindex(arr.data, clamp_bounds(arr, I)...)
-@inline Base.setindex!(arr::CircularArray, v, I::Vararg{Int}) = @inbounds setindex!(arr.data, v, clamp_bounds(arr, I)...)
+@inline Base.getindex(arr::CircularArray{T,N}, I::Vararg{<:Integer,N}) where {T,N} =
+    @inbounds getindex(arr.data, mod.(I, axes(arr))...)
+@inline Base.setindex!(arr::CircularArray{T,N}, v, I::Vararg{<:Integer,N}) where {T,N} =
+    @inbounds setindex!(arr.data, v, mod.(I, axes(arr))...)
 @inline Base.size(arr::CircularArray) = size(arr.data)
 @inline Base.axes(arr::CircularArray) = axes(arr.data)
+Base.parent(arr::CircularArray) = arr.data
 
 @inline Base.checkbounds(::CircularArray, _...) = nothing
 

--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -45,24 +45,6 @@ CircularArray(def::T, size) where T = CircularArray(fill(def, size))
 @inline Base.axes(arr::CircularArray) = axes(arr.data)
 Base.parent(arr::CircularArray) = arr.data
 
-@inline function Base.to_indices(arr::CircularArray, ax, I::Tuple{Integer, Vararg{Any}})
-    J = mod(I[1], ax[1])
-    (J, Base.to_indices(arr, Base.tail(ax), Base.tail(I))...)
-end
-@inline function Base.to_indices(arr::CircularArray, ax::Tuple{}, I::Tuple{Integer, Vararg{Any}})
-    (1, Base.to_indices(arr, ax, (Base.tail(I)))...)
-end
-@inline function Base.to_indices(arr::CircularArray, ax, I::Tuple{CartesianIndex{M}, Vararg{Any}}) where {M}
-    J = ntuple(d -> mod(I[1].I[d], ax[d]), Val(M))
-    (J..., Base.to_indices(arr, ax[M:end], Base.tail(I))...)
-end
-@inline Base.to_indices(arr::CircularArray, I::Tuple{Vararg{Union{Integer, CartesianIndex}}}) =
-    Base.to_indices(arr, axes(arr.data), I) # this method would normally omit axes
-@inline Base.to_indices(arr::CircularArray, I::Tuple{Vararg{Int}}) =
-    Base.to_indices(arr, axes(arr.data), I) # this method would otherwise just return I
-@inline Base.to_indices(arr::CircularArray, I::Tuple{Vararg{Integer}}) =
-    Base.to_indices(arr, axes(arr.data), I)
-
 @inline function Base.checkbounds(arr::CircularArray, I...)
     J = Base.to_indices(arr, I)
     length(J) == 1 || length(J) >= ndims(arr) || throw(BoundsError(arr, I))
@@ -77,7 +59,7 @@ end
 CircularVector(data::AbstractArray{T, 1}) where T = CircularVector{T}(data)
 CircularVector(def::T, size::Int) where T = CircularVector{T}(fill(def, size))
 
-Base.IndexStyle(::Type{CircularArray{T,N,A}}) where {T,N,A} = IndexStyle(A)
+Base.IndexStyle(::Type{CircularArray{T,N,A}}) where {T,N,A} = IndexCartesian()
 Base.IndexStyle(::Type{<:CircularVector}) = IndexLinear()
 
 function Base.showarg(io::IO, arr::CircularArray, toplevel)

--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -31,14 +31,14 @@ CircularArray(data::AbstractArray{T,N}) where {T,N} = CircularArray{T,N}(data)
 CircularArray{T}(data::AbstractArray{T,N}) where {T,N} = CircularArray{T,N}(data)
 CircularArray(def::T, size) where T = CircularArray(fill(def, size))
 
-@inline Base.getindex(arr::CircularArray, i::Integer) =
+@inline Base.getindex(arr::CircularArray, i::Int) =
     @inbounds getindex(arr.data, mod1(i, length(arr.data)))
-@inline Base.getindex(arr::CircularArray{T,N}, I::Vararg{<:Integer,N}) where {T,N} =
+@inline Base.getindex(arr::CircularArray{T,N}, I::Vararg{<:Int,N}) where {T,N} =
     @inbounds getindex(arr.data, map(mod, I, axes(arr.data))...)
 
-@inline Base.setindex!(arr::CircularArray, v, i::Integer) =
+@inline Base.setindex!(arr::CircularArray, v, i::Int) =
     @inbounds setindex!(arr.data, v, mod1(i, length(arr.data)))
-@inline Base.setindex!(arr::CircularArray{T,N}, v, I::Vararg{<:Integer,N}) where {T,N} =
+@inline Base.setindex!(arr::CircularArray{T,N}, v, I::Vararg{<:Int,N}) where {T,N} =
     @inbounds setindex!(arr.data, v, map(mod, I, axes(arr.data))...)
 
 @inline Base.size(arr::CircularArray) = size(arr.data)

--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -45,15 +45,23 @@ CircularArray(def::T, size) where T = CircularArray(fill(def, size))
 @inline Base.axes(arr::CircularArray) = axes(arr.data)
 Base.parent(arr::CircularArray) = arr.data
 
+@inline function Base.to_indices(arr::CircularArray, ax, I::Tuple{Integer, Vararg{Any}})
+    J = mod(I[1], ax[1])
+    (J, Base.to_indices(arr, Base.tail(ax), Base.tail(I))...)
+end
+@inline function Base.to_indices(arr::CircularArray, ax::Tuple{}, I::Tuple{Integer, Vararg{Any}})
+    (1, Base.to_indices(arr, ax, (Base.tail(I)))...)
+end
 @inline function Base.to_indices(arr::CircularArray, ax, I::Tuple{CartesianIndex{M}, Vararg{Any}}) where {M}
     J = ntuple(d -> mod(I[1].I[d], ax[d]), Val(M))
-    Base.to_indices(arr, ax[M:end], (J..., Base.tail(I)...))
+    (J..., Base.to_indices(arr, ax[M:end], Base.tail(I))...)
 end
 @inline Base.to_indices(arr::CircularArray, I::Tuple{Vararg{Union{Integer, CartesianIndex}}}) =
-    to_indices(arr, axes(arr), I) # this method would normally omit axes, but we need them.
-# and then these two are needed to solve ambiguity:
-@inline Base.to_indices(arr::CircularArray, I::Tuple{Vararg{Int}}) = I
-@inline Base.to_indices(arr::CircularArray, I::Tuple{Vararg{Integer}}) = to_indices(arr, (), I)
+    Base.to_indices(arr, axes(arr.data), I) # this method would normally omit axes
+@inline Base.to_indices(arr::CircularArray, I::Tuple{Vararg{Int}}) =
+    Base.to_indices(arr, axes(arr.data), I) # this method would otherwise just return I
+@inline Base.to_indices(arr::CircularArray, I::Tuple{Vararg{Integer}}) =
+    Base.to_indices(arr, axes(arr.data), I)
 
 @inline function Base.checkbounds(arr::CircularArray, I...)
     J = Base.to_indices(arr, I)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,10 @@ end
 
     a2 = CircularArray(4, (2, 3))
     @test isa(a2, CircularArray{Int, 2})
+
+    @test a1[2, 3, 1] == 17 # trailing index
+    @test a1[2, 3, 99] == 17
+    @test a1[2, 3, :] == [17]
 end
 
 @testset "offset indices" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,12 +79,30 @@ end
     a2 = CircularArray(4, (2, 3))
     @test isa(a2, CircularArray{Int, 2})
 
-    @test a1[3] == a1[3,1] # linear indexing
+    @test IndexStyle(a1) == IndexLinear()
+    @test a1[3] == a1[3,1]
     @test a1[4] == a1[1,2]
+    @test a1[-1] == a1[length(a1)-1]
 
     @test a1[2, 3, 1] == 17 # trailing index
     @test a1[2, 3, 99] == 17
     @test a1[2, 3, :] == [17]
+end
+
+@testset "3-array" begin
+    t3 = collect(reshape('a':'x', 2,3,4))
+    c3 = CircularArray(t3)
+
+    @test c3[1,3,3] == c3[3,3,3] == c3[3,3,7]
+
+    c3[3,3,7] = 'Z'
+    @test t3[1,3,3] == 'Z'
+
+    @test IndexStyle(c3) == IndexLinear()
+    @test c3[-1] == t3[length(t3)-1]
+
+    @test_throws BoundsError c3[2,3] # too few indices
+    @test_throws BoundsError c3[CartesianIndex(2,3)]
 end
 
 @testset "offset indices" begin
@@ -110,6 +128,6 @@ end
     @test collect(a) == data
     @test all(a[x,y] == data[mod1(x+1,3),mod1(y+1,3)] for x=-10:10, y=-10:10)
     @test a[i,1] == CircularArray(OffsetArray([5,6,4,5,6],-2:2))
-    @test a[CartesianIndex.(i,i)] == CircularArray(OffsetArray([5,9,1,5,9],-2:2))
+    @test_broken a[CartesianIndex.(i,i)] == CircularArray(OffsetArray([5,9,1,5,9],-2:2))
     @test a[a .> 4] == 5:9
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,10 +98,16 @@ end
     t3 = collect(reshape('a':'x', 2,3,4))
     c3 = CircularArray(t3)
 
-    @test c3[1,3,3] == c3[3,3,3] == c3[3,3,7]
+    @test c3[1,3,3] == c3[3,3,3] == c3[3,3,7] == c3[3,3,7,1]
 
     c3[3,3,7] = 'Z'
     @test t3[1,3,3] == 'Z'
+
+    @test c3[3, CartesianIndex(3,7)] == 'Z'
+    c3[Int32(3), CartesianIndex(3,7)] = 'ζ'
+    @test t3[1,3,3] == 'ζ'
+
+    @test vec(c3[:, [CartesianIndex()], 1, 5]) == vec(t3[:, 1, 1])
 
     @test IndexStyle(c3) == IndexLinear()
     @test c3[-1] == t3[length(t3)-1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,16 +69,11 @@ end
     a1[2, 3] = 17
     @test a1[2, 3] == 17
     @test a1[-1, 7] == 17
+    @test a1[CartesianIndex(-1, 7)] == 17
     @test a1[-1:5, 4:10][1, 4] == 17
     @test a1[:, -1:-1][2, 1] == 17
-    @test !isa(a1, CircularVector)
-    @test !isa(a1, AbstractVector)
-    @test isa(a1, AbstractArray)
-
-    @test size(reshape(a1, (2, 2, 3))) == (2, 2, 3)
-
-    a2 = CircularArray(4, (2, 3))
-    @test isa(a2, CircularArray{Int, 2})
+    a1[CartesianIndex(-2, 7)] = 99
+    @test a1[1, 3] == 99
 
     @test IndexStyle(a1) == IndexLinear()
     @test a1[3] == a1[3,1]
@@ -88,6 +83,15 @@ end
     @test a1[2, 3, 1] == 17 # trailing index
     @test a1[2, 3, 99] == 17
     @test a1[2, 3, :] == [17]
+
+    @test !isa(a1, CircularVector)
+    @test !isa(a1, AbstractVector)
+    @test isa(a1, AbstractArray)
+
+    @test size(reshape(a1, (2, 2, 3))) == (2, 2, 3)
+
+    a2 = CircularArray(4, (2, 3))
+    @test isa(a2, CircularArray{Int, 2})
 end
 
 @testset "3-array" begin
@@ -129,6 +133,6 @@ end
     @test collect(a) == data
     @test all(a[x,y] == data[mod1(x+1,3),mod1(y+1,3)] for x=-10:10, y=-10:10)
     @test a[i,1] == CircularArray(OffsetArray([5,6,4,5,6],-2:2))
-    @test_broken a[CartesianIndex.(i,i)] == CircularArray(OffsetArray([5,9,1,5,9],-2:2))
+    @test a[CartesianIndex.(i,i)] == CircularArray(OffsetArray([5,9,1,5,9],-2:2))
     @test a[a .> 4] == 5:9
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,7 @@ end
     @test !isa(v1, AbstractVector{String})
     @test v1[2] == v1[2 + length(v1)]
 
+    @test IndexStyle(v1) == IndexLinear()
     @test v1[0] == data[end]
     @test v1[-4:10] == [data; data; data]
     @test v1[-3:1][-1] == data[end]
@@ -75,7 +76,7 @@ end
     a1[CartesianIndex(-2, 7)] = 99
     @test a1[1, 3] == 99
 
-    @test IndexStyle(a1) == IndexLinear()
+    @test IndexStyle(a1) == IndexCartesian()
     @test a1[3] == a1[3,1]
     @test a1[Int32(4)] == a1[1,2]
     @test a1[-1] == a1[length(a1)-1]
@@ -109,7 +110,7 @@ end
 
     @test vec(c3[:, [CartesianIndex()], 1, 5]) == vec(t3[:, 1, 1])
 
-    @test IndexStyle(c3) == IndexLinear()
+    @test IndexStyle(c3) == IndexCartesian()
     @test c3[-1] == t3[length(t3)-1]
 
     @test_throws BoundsError c3[2,3] # too few indices

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,6 +65,7 @@ end
     a1 = CircularArray(b_arr)
     @test size(a1) == (3, 4)
     @test a1[2, 3] == 14
+    @test a1[2, Int32(3)] == 14
     a1[2, 3] = 17
     @test a1[2, 3] == 17
     @test a1[-1, 7] == 17
@@ -81,7 +82,7 @@ end
 
     @test IndexStyle(a1) == IndexLinear()
     @test a1[3] == a1[3,1]
-    @test a1[4] == a1[1,2]
+    @test a1[Int32(4)] == a1[1,2]
     @test a1[-1] == a1[length(a1)-1]
 
     @test a1[2, 3, 1] == 17 # trailing index

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,6 +79,9 @@ end
     a2 = CircularArray(4, (2, 3))
     @test isa(a2, CircularArray{Int, 2})
 
+    @test a1[3] == a1[3,1] # linear indexing
+    @test a1[4] == a1[1,2]
+
     @test a1[2, 3, 1] == 17 # trailing index
     @test a1[2, 3, 99] == 17
     @test a1[2, 3, :] == [17]


### PR DESCRIPTION
Before:
```
julia> ca = CircularArray(rand(Int8, 10,10));

julia> @btime [$ca[i,j] for i in 1:21, j in 1:21];
  52.352 μs (886 allocations: 48.91 KiB)
```
After:
```
julia> @btime [$ca[i,j] for i in 1:21, j in 1:21]
  4.009 μs (1 allocation: 544 bytes)
21×21 Matrix{Int8}:
 -69  -22   -83  -28    -7   -20   106  -119  …  -28    -7   -20   106  -119    59  -111  -69
  25  -72  -123  118    36   -54   -81   118     118    36   -54   -81   118   -90   -77   25
...
```