### PR TITLE
resolve an ambiguity

### DIFF
--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -79,6 +79,7 @@ end
 @inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Base.DimOrInd, Vararg{Base.DimOrInd}}) where T = _similar(arr, T, dims)
 # Ambiguity resolution with Base
 @inline Base.similar(arr::CircularArray, ::Type{T}, dims::Dims) where T = _similar(arr, T, dims)
+@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Integer, Vararg{Integer}}) where T = _similar(arr, T, dims)
 @inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Union{Integer, Base.OneTo}, Vararg{Union{Integer, Base.OneTo}}}) where T = _similar(arr, T, dims)
 
 @inline _similar(::Type{CircularArray{T,N,A}}, dims) where {T,N,A} = CircularArray{T,N}(similar(A, dims))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ end
         @test @inferred(a[[1]']) isa CircularArray{Int64,2}
         @test @inferred(axes(a)) isa Tuple{Vararg{AbstractUnitRange}}
         @test @inferred(similar(a)) isa typeof(a)
-        @test @inferred(similar(a, size(a))) isa typeof(a)
+        @test @inferred(similar(a, Float64, size(a))) isa typeof(a)
         @test @inferred(similar(typeof(a), axes(a))) isa typeof(a)
         @test @inferred(a[a]) isa typeof(a)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ end
         @test @inferred(a[[1]']) isa CircularArray{Int64,2}
         @test @inferred(axes(a)) isa Tuple{Vararg{AbstractUnitRange}}
         @test @inferred(similar(a)) isa typeof(a)
-        @test @inferred(similar(a, Float64, size(a))) isa typeof(a)
+        @test @inferred(similar(a, Float64, size(a))) isa CircularArray{Float64}
         @test @inferred(similar(typeof(a), axes(a))) isa typeof(a)
         @test @inferred(a[a]) isa typeof(a)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ end
         @test @inferred(a[[1]']) isa CircularArray{Int64,2}
         @test @inferred(axes(a)) isa Tuple{Vararg{AbstractUnitRange}}
         @test @inferred(similar(a)) isa typeof(a)
+        @test @inferred(similar(a, size(a))) isa typeof(a)
         @test @inferred(similar(typeof(a), axes(a))) isa typeof(a)
         @test @inferred(a[a]) isa typeof(a)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,7 +35,7 @@ end
         @test @inferred(a[[1]']) isa CircularArray{Int64,2}
         @test @inferred(axes(a)) isa Tuple{Vararg{AbstractUnitRange}}
         @test @inferred(similar(a)) isa typeof(a)
-        @test @inferred(similar(a, Float64, size(a))) isa CircularArray{Float64}
+        @test @inferred(similar(a, Float64, Int8.(size(a)))) isa CircularArray{Float64}
         @test @inferred(similar(typeof(a), axes(a))) isa typeof(a)
         @test @inferred(a[a]) isa typeof(a)
     end


### PR DESCRIPTION
```julia
similar(arr::CircularArray, ::Type{T}, dims::Tuple{Union{Integer, AbstractUnitRange}, Vararg{Union{Integer, AbstractUnitRange}}}) where T   
     @ CircularArrays C:\Users\pty\.julia\packages\CircularArrays\6Q9fC\src\CircularArrays.jl:71
similar(a::AbstractArray, ::Type{T}, dims::Tuple{Integer, Vararg{Integer}}) where T
     @ Base abstractarray.jl:837
```