### PR TITLE
implementation of `splice!`

### DIFF
--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -156,7 +156,7 @@ function Base.splice!(a::CircularVector, i::Integer, ins=Base._default_splice)
   splice!(a.data, mod(i, eachindex(IndexLinear(), a.data)), ins)
 end
 
-# modulo unit ranges aren't in Base, so we basically reimplement splice!
+# modulo unit ranges aren't in Base, so we basically reimplement splice! using modular logic
 function Base.splice!(a::CircularVector, r::AbstractUnitRange{<:Integer}, ins=Base._default_splice)
   v = a[r]
   m = length(ins)

--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -12,10 +12,10 @@ export CircularArray, CircularVector, CircularMatrix
 
     array[index...] == array[mod1.(index, size)...]
 """
-struct CircularArray{T, N, A <: AbstractArray{T,N}} <: AbstractArray{T,N}
-    data::A
-    CircularArray{T,N}(data::A) where A <: AbstractArray{T,N} where {T,N} = new{T,N,A}(data)
-    CircularArray{T,N,A}(data::A) where A <: AbstractArray{T,N} where {T,N} = new{T,N,A}(data)
+struct CircularArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
+  data::A
+  CircularArray{T,N}(data::A) where A<:AbstractArray{T,N} where {T,N} = new{T,N,A}(data)
+  CircularArray{T,N,A}(data::A) where A<:AbstractArray{T,N} where {T,N} = new{T,N,A}(data)
 end
 
 """
@@ -26,7 +26,7 @@ Alias for [`CircularArray{T,1,A}`](@ref).
 
     array[index] == array[mod1(index, length)]
 """
-const CircularVector{T} = CircularArray{T, 1}
+const CircularVector{T} = CircularArray{T,1}
 
 """
     CircularMatrix{T,A} <: AbstractMatrix{T}
@@ -34,7 +34,7 @@ const CircularVector{T} = CircularArray{T, 1}
 Two-dimensional array backed by an `AbstractArray{T, 2}` of type `A` with fixed size and circular indexing.
 Alias for [`CircularArray{T,2,A}`](@ref).
 """
-const CircularMatrix{T} = CircularArray{T, 2}
+const CircularMatrix{T} = CircularArray{T,2}
 
 """
     CircularArray(data)
@@ -70,23 +70,23 @@ Base.IndexStyle(::Type{<:CircularVector}) = IndexLinear()
 @inline Base.copy(arr::CircularArray) = CircularArray(copy(parent(arr)))
 
 @inline function Base.checkbounds(arr::CircularArray, I...)
-    J = Base.to_indices(arr, I)
-    length(J) == 1 || length(J) >= ndims(arr) || throw(BoundsError(arr, I))
-    nothing
+  J = Base.to_indices(arr, I)
+  length(J) == 1 || length(J) >= ndims(arr) || throw(BoundsError(arr, I))
+  nothing
 end
 
 @inline _similar(arr::CircularArray, ::Type{T}, dims) where T = CircularArray(similar(parent(arr), T, dims))
-@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Base.DimOrInd, Vararg{Base.DimOrInd}}) where T = _similar(arr, T, dims)
+@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Base.DimOrInd,Vararg{Base.DimOrInd}}) where T = _similar(arr, T, dims)
 # Ambiguity resolution with Base
 @inline Base.similar(arr::CircularArray, ::Type{T}, dims::Dims) where T = _similar(arr, T, dims)
-@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Integer, Vararg{Integer}}) where T = _similar(arr, T, dims)
-@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Union{Integer, Base.OneTo}, Vararg{Union{Integer, Base.OneTo}}}) where T = _similar(arr, T, dims)
+@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Integer,Vararg{Integer}}) where T = _similar(arr, T, dims)
+@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Union{Integer,Base.OneTo},Vararg{Union{Integer,Base.OneTo}}}) where T = _similar(arr, T, dims)
 
 @inline _similar(::Type{CircularArray{T,N,A}}, dims) where {T,N,A} = CircularArray{T,N}(similar(A, dims))
-@inline Base.similar(CA::Type{CircularArray{T,N,A}}, dims::Tuple{Base.DimOrInd, Vararg{Base.DimOrInd}}) where {T,N,A} = _similar(CA, dims)
+@inline Base.similar(CA::Type{CircularArray{T,N,A}}, dims::Tuple{Base.DimOrInd,Vararg{Base.DimOrInd}}) where {T,N,A} = _similar(CA, dims)
 # Ambiguity resolution with Base
 @inline Base.similar(CA::Type{CircularArray{T,N,A}}, dims::Dims) where {T,N,A} = _similar(CA, dims)
-@inline Base.similar(CA::Type{CircularArray{T,N,A}}, dims::Tuple{Union{Integer, Base.OneTo}, Vararg{Union{Integer, Base.OneTo}}}) where {T,N,A} = _similar(CA, dims)
+@inline Base.similar(CA::Type{CircularArray{T,N,A}}, dims::Tuple{Union{Integer,Base.OneTo},Vararg{Union{Integer,Base.OneTo}}}) where {T,N,A} = _similar(CA, dims)
 
 @inline Broadcast.BroadcastStyle(::Type{CircularArray{T,N,A}}) where {T,N,A} = Broadcast.ArrayStyle{CircularArray{T,N,A}}()
 @inline Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{CircularArray{T,N,A}}}, ::Type{ElType}) where {T,N,A,ElType} = CircularArray(similar(convert(Broadcast.Broadcasted{typeof(Broadcast.BroadcastStyle(A))}, bc), ElType))
@@ -94,10 +94,10 @@ end
 @inline Base.dataids(arr::CircularArray) = Base.dataids(parent(arr))
 
 function Base.showarg(io::IO, arr::CircularArray, toplevel)
-    print(io, ndims(arr) == 1 ? "CircularVector(" : "CircularArray(")
-    Base.showarg(io, parent(arr), false)
-    print(io, ')')
-    # toplevel && print(io, " with eltype ", eltype(arr))
+  print(io, ndims(arr) == 1 ? "CircularVector(" : "CircularArray(")
+  Base.showarg(io, parent(arr), false)
+  print(io, ')')
+  # toplevel && print(io, " with eltype ", eltype(arr))
 end
 
 """
@@ -105,14 +105,14 @@ end
 
 Create a `CircularVector` wrapping the array `data`.
 """
-CircularVector(data::AbstractArray{T, 1}) where T = CircularVector{T}(data)
+CircularVector(data::AbstractArray{T,1}) where T = CircularVector{T}(data)
 
 """
     CircularMatrix(data)
 
 Create a `CircularMatrix` wrapping the array `data`.
 """
-CircularMatrix(data::AbstractArray{T, 2}) where T = CircularMatrix{T}(data)
+CircularMatrix(data::AbstractArray{T,2}) where T = CircularMatrix{T}(data)
 
 
 """
@@ -127,7 +127,7 @@ CircularVector(def::T, size::Int) where T = CircularVector{T}(fill(def, size))
 
 Create a `CircularMatrix` of size `size` filled with value `def`.
 """
-CircularMatrix(def::T, size::NTuple{2, Integer}) where T = CircularMatrix{T}(fill(def, size))
+CircularMatrix(def::T, size::NTuple{2,Integer}) where T = CircularMatrix{T}(fill(def, size))
 
 Base.empty(::CircularVector{T}, ::Type{U}=T) where {T,U} = CircularVector{U}(U[])
 Base.empty!(a::CircularVector) = (empty!(parent(a)); a)
@@ -138,56 +138,31 @@ Base.pop!(a::CircularVector) = pop!(parent(a))
 Base.sizehint!(a::CircularVector, sz::Integer) = (sizehint!(parent(a), sz); a)
 
 function Base.deleteat!(a::CircularVector, i::Integer)
-    deleteat!(a.data, mod(i, eachindex(IndexLinear(), a.data)))
-    a
+  deleteat!(a.data, mod(i, eachindex(IndexLinear(), a.data)))
+  a
 end
 
 function Base.deleteat!(a::CircularVector, inds)
-    deleteat!(a.data, sort!(unique(map(i -> mod(i, eachindex(IndexLinear(), a.data)), inds))))
-    a
+  deleteat!(a.data, sort!(unique(map(i -> mod(i, eachindex(IndexLinear(), a.data)), inds))))
+  a
 end
 
 function Base.insert!(a::CircularVector, i::Integer, item)
-    insert!(a.data, mod(i, eachindex(IndexLinear(), a.data)), item)
-    a
+  insert!(a.data, mod(i, eachindex(IndexLinear(), a.data)), item)
+  a
 end
-
-function Base.splice!(a::CircularVector, i::Integer, ins=Base._default_splice)
-  splice!(a.data, mod(i, eachindex(IndexLinear(), a.data)), ins)
-end
-
-# modulo unit ranges aren't in Base, so we basically reimplement splice! using modular logic
-function Base.splice!(a::CircularVector, r::AbstractUnitRange{<:Integer}, ins=Base._default_splice)
-  v = a[r]
-  m = length(ins)
-  if m == 0
-    deleteat!(a, r)
-    return v
-  end
-  b = eachindex(IndexLinear(), a.data)
-
-  n = length(a)
-  f = mod(first(r), b)
-  l = mod(last(r), b)
-  d = length(r)
-
-  if m < d
-    delta = d - m
-    ind = f - 1 < n - l ? f : l - delta + 1
-    Base._deleteat!(a.data, mod(ind, b), delta)
-  elseif m > d
-    ind = f - 1 < n - l ? f : l + 1
-    Base._growat!(a.data, mod(ind, b), m - d)
-  end
-
-  k = 1
-  for x in ins
-    a[f+k-1] = x
-    k += 1
-  end
+function Base.splice!(a::CircularVector, i::Union{Integer,AbstractUnitRange{<:Integer}}, ins=Base._default_splice)
+  v = a[i]
+  idx = mod(first(i), eachindex(IndexLinear(), a.data))
+  deleteat!(a, i)
+  splice!(a.data, idx:idx-1, ins)
   return v
 end
 
-Base.splice!(a::CircularVector, inds) = splice!(a.data, inds)
+function Base.splice!(a::CircularVector, inds)
+  dltds = [a[i] for i in inds]
+  deleteat!(a, dltds)
+  dltds
+end
 
 end

--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -152,4 +152,42 @@ function Base.insert!(a::CircularVector, i::Integer, item)
     a
 end
 
+function Base.splice!(a::CircularVector, i::Integer, ins=Base._default_splice)
+  splice!(a.data, mod(i, eachindex(IndexLinear(), a.data)), ins)
+end
+
+# modulo unit ranges aren't in Base, so we basically reimplement splice!
+function Base.splice!(a::CircularVector, r::AbstractUnitRange{<:Integer}, ins=Base._default_splice)
+  v = a[r]
+  m = length(ins)
+  if m == 0
+    deleteat!(a, r)
+    return v
+  end
+  b = eachindex(IndexLinear(), a.data)
+
+  n = length(a)
+  f = mod(first(r), b)
+  l = mod(last(r), b)
+  d = length(r)
+
+  if m < d
+    delta = d - m
+    ind = f - 1 < n - l ? f : l - delta + 1
+    Base._deleteat!(a.data, mod(ind, b), delta)
+  elseif m > d
+    ind = f - 1 < n - l ? f : l + 1
+    Base._growat!(a.data, mod(ind, b), m - d)
+  end
+
+  k = 1
+  for x in ins
+    a[f+k-1] = x
+    k += 1
+  end
+  return v
+end
+
+Base.splice!(a::CircularVector, inds) = splice!(a.data, inds)
+
 end

--- a/src/CircularArrays.jl
+++ b/src/CircularArrays.jl
@@ -12,10 +12,10 @@ export CircularArray, CircularVector, CircularMatrix
 
     array[index...] == array[mod1.(index, size)...]
 """
-struct CircularArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
-  data::A
-  CircularArray{T,N}(data::A) where A<:AbstractArray{T,N} where {T,N} = new{T,N,A}(data)
-  CircularArray{T,N,A}(data::A) where A<:AbstractArray{T,N} where {T,N} = new{T,N,A}(data)
+struct CircularArray{T, N, A <: AbstractArray{T,N}} <: AbstractArray{T,N}
+    data::A
+    CircularArray{T,N}(data::A) where A <: AbstractArray{T,N} where {T,N} = new{T,N,A}(data)
+    CircularArray{T,N,A}(data::A) where A <: AbstractArray{T,N} where {T,N} = new{T,N,A}(data)
 end
 
 """
@@ -26,7 +26,7 @@ Alias for [`CircularArray{T,1,A}`](@ref).
 
     array[index] == array[mod1(index, length)]
 """
-const CircularVector{T} = CircularArray{T,1}
+const CircularVector{T} = CircularArray{T, 1}
 
 """
     CircularMatrix{T,A} <: AbstractMatrix{T}
@@ -34,7 +34,7 @@ const CircularVector{T} = CircularArray{T,1}
 Two-dimensional array backed by an `AbstractArray{T, 2}` of type `A` with fixed size and circular indexing.
 Alias for [`CircularArray{T,2,A}`](@ref).
 """
-const CircularMatrix{T} = CircularArray{T,2}
+const CircularMatrix{T} = CircularArray{T, 2}
 
 """
     CircularArray(data)
@@ -70,23 +70,23 @@ Base.IndexStyle(::Type{<:CircularVector}) = IndexLinear()
 @inline Base.copy(arr::CircularArray) = CircularArray(copy(parent(arr)))
 
 @inline function Base.checkbounds(arr::CircularArray, I...)
-  J = Base.to_indices(arr, I)
-  length(J) == 1 || length(J) >= ndims(arr) || throw(BoundsError(arr, I))
-  nothing
+    J = Base.to_indices(arr, I)
+    length(J) == 1 || length(J) >= ndims(arr) || throw(BoundsError(arr, I))
+    nothing
 end
 
 @inline _similar(arr::CircularArray, ::Type{T}, dims) where T = CircularArray(similar(parent(arr), T, dims))
-@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Base.DimOrInd,Vararg{Base.DimOrInd}}) where T = _similar(arr, T, dims)
+@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Base.DimOrInd, Vararg{Base.DimOrInd}}) where T = _similar(arr, T, dims)
 # Ambiguity resolution with Base
 @inline Base.similar(arr::CircularArray, ::Type{T}, dims::Dims) where T = _similar(arr, T, dims)
-@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Integer,Vararg{Integer}}) where T = _similar(arr, T, dims)
-@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Union{Integer,Base.OneTo},Vararg{Union{Integer,Base.OneTo}}}) where T = _similar(arr, T, dims)
+@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Integer, Vararg{Integer}}) where T = _similar(arr, T, dims)
+@inline Base.similar(arr::CircularArray, ::Type{T}, dims::Tuple{Union{Integer, Base.OneTo}, Vararg{Union{Integer, Base.OneTo}}}) where T = _similar(arr, T, dims)
 
 @inline _similar(::Type{CircularArray{T,N,A}}, dims) where {T,N,A} = CircularArray{T,N}(similar(A, dims))
-@inline Base.similar(CA::Type{CircularArray{T,N,A}}, dims::Tuple{Base.DimOrInd,Vararg{Base.DimOrInd}}) where {T,N,A} = _similar(CA, dims)
+@inline Base.similar(CA::Type{CircularArray{T,N,A}}, dims::Tuple{Base.DimOrInd, Vararg{Base.DimOrInd}}) where {T,N,A} = _similar(CA, dims)
 # Ambiguity resolution with Base
 @inline Base.similar(CA::Type{CircularArray{T,N,A}}, dims::Dims) where {T,N,A} = _similar(CA, dims)
-@inline Base.similar(CA::Type{CircularArray{T,N,A}}, dims::Tuple{Union{Integer,Base.OneTo},Vararg{Union{Integer,Base.OneTo}}}) where {T,N,A} = _similar(CA, dims)
+@inline Base.similar(CA::Type{CircularArray{T,N,A}}, dims::Tuple{Union{Integer, Base.OneTo}, Vararg{Union{Integer, Base.OneTo}}}) where {T,N,A} = _similar(CA, dims)
 
 @inline Broadcast.BroadcastStyle(::Type{CircularArray{T,N,A}}) where {T,N,A} = Broadcast.ArrayStyle{CircularArray{T,N,A}}()
 @inline Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{CircularArray{T,N,A}}}, ::Type{ElType}) where {T,N,A,ElType} = CircularArray(similar(convert(Broadcast.Broadcasted{typeof(Broadcast.BroadcastStyle(A))}, bc), ElType))
@@ -94,10 +94,10 @@ end
 @inline Base.dataids(arr::CircularArray) = Base.dataids(parent(arr))
 
 function Base.showarg(io::IO, arr::CircularArray, toplevel)
-  print(io, ndims(arr) == 1 ? "CircularVector(" : "CircularArray(")
-  Base.showarg(io, parent(arr), false)
-  print(io, ')')
-  # toplevel && print(io, " with eltype ", eltype(arr))
+    print(io, ndims(arr) == 1 ? "CircularVector(" : "CircularArray(")
+    Base.showarg(io, parent(arr), false)
+    print(io, ')')
+    # toplevel && print(io, " with eltype ", eltype(arr))
 end
 
 """
@@ -105,14 +105,14 @@ end
 
 Create a `CircularVector` wrapping the array `data`.
 """
-CircularVector(data::AbstractArray{T,1}) where T = CircularVector{T}(data)
+CircularVector(data::AbstractArray{T, 1}) where T = CircularVector{T}(data)
 
 """
     CircularMatrix(data)
 
 Create a `CircularMatrix` wrapping the array `data`.
 """
-CircularMatrix(data::AbstractArray{T,2}) where T = CircularMatrix{T}(data)
+CircularMatrix(data::AbstractArray{T, 2}) where T = CircularMatrix{T}(data)
 
 
 """
@@ -127,7 +127,7 @@ CircularVector(def::T, size::Int) where T = CircularVector{T}(fill(def, size))
 
 Create a `CircularMatrix` of size `size` filled with value `def`.
 """
-CircularMatrix(def::T, size::NTuple{2,Integer}) where T = CircularMatrix{T}(fill(def, size))
+CircularMatrix(def::T, size::NTuple{2, Integer}) where T = CircularMatrix{T}(fill(def, size))
 
 Base.empty(::CircularVector{T}, ::Type{U}=T) where {T,U} = CircularVector{U}(U[])
 Base.empty!(a::CircularVector) = (empty!(parent(a)); a)
@@ -138,31 +138,31 @@ Base.pop!(a::CircularVector) = pop!(parent(a))
 Base.sizehint!(a::CircularVector, sz::Integer) = (sizehint!(parent(a), sz); a)
 
 function Base.deleteat!(a::CircularVector, i::Integer)
-  deleteat!(a.data, mod(i, eachindex(IndexLinear(), a.data)))
-  a
+    deleteat!(a.data, mod(i, eachindex(IndexLinear(), a.data)))
+    a
 end
 
 function Base.deleteat!(a::CircularVector, inds)
-  deleteat!(a.data, sort!(unique(map(i -> mod(i, eachindex(IndexLinear(), a.data)), inds))))
-  a
+    deleteat!(a.data, sort!(unique(map(i -> mod(i, eachindex(IndexLinear(), a.data)), inds))))
+    a
 end
 
 function Base.insert!(a::CircularVector, i::Integer, item)
-  insert!(a.data, mod(i, eachindex(IndexLinear(), a.data)), item)
-  a
+    insert!(a.data, mod(i, eachindex(IndexLinear(), a.data)), item)
+    a
 end
 function Base.splice!(a::CircularVector, i::Union{Integer,AbstractUnitRange{<:Integer}}, ins=Base._default_splice)
-  v = a[i]
-  idx = mod(first(i), eachindex(IndexLinear(), a.data))
-  deleteat!(a, i)
-  splice!(a.data, idx:idx-1, ins)
-  return v
+    v = a[i]
+    idx = mod(first(i), eachindex(IndexLinear(), a.data))
+    deleteat!(a, i)
+    splice!(a.data, idx:idx-1, ins)
+    v
 end
 
 function Base.splice!(a::CircularVector, inds)
-  dltds = [a[i] for i in inds]
-  deleteat!(a, dltds)
-  dltds
+    dltds = [a[i] for i in inds]
+    deleteat!(a, dltds)
+    dltds
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -149,45 +149,6 @@ end
             @test v5 == CircularVector([1,2,3,-1,-2,-3,-4])
         end
     end
-    @testset "resize!" begin
-        @test_throws ArgumentError("new length must be ≥ 0") resize!(CircularVector([]), -2)
-        v = CircularVector([1,2,3,4,5,6,7])
-        resize!(v, 3)
-        @test length(v) == 3
-
-        # ensure defining `resize!` induces `push!` and `append!` methods
-        @testset "push!" begin
-            v = CircularVector([1,2,3])
-            push!(v, 42)
-            @test v == CircularVector([1,2,3,42])
-            push!(v, -9, -99, -999)
-            @test v == CircularVector([1,2,3,42, -9, -99, -999])
-        end
-
-        @testset "append!" begin
-            v1 = CircularVector([1,2,3])
-            append!(v1, [-9, -99, -999])
-            @test v1 == CircularVector([1,2,3, -9, -99, -999])
-
-            v2 = CircularVector([1,2,3])
-            append!(v2, CircularVector([-1,-2]))
-            @test v2 == CircularVector([1,2,3,-1,-2])
-
-            v3 = CircularVector([1,2,3])
-            append!(v3, [4, 5], [6])
-            @test v3 == CircularVector([1,2,3,4,5,6])
-
-            v4 = CircularVector([1,2,3])
-            o4 = OffsetVector([-1,-2,-3], -2:0)
-            append!(v4, o4)
-            @test v4 == CircularVector([1,2,3,-1,-2,-3])
-
-            v5 = CircularVector([1,2,3])
-            o5 = OffsetVector([-1,-2,-3], -2:0)
-            append!(v5, o5, -4)
-            @test v5 == CircularVector([1,2,3,-1,-2,-3,-4])
-        end
-    end
 
     @testset "pop!" begin
         v1 = CircularVector([1,2,3,42])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,340 +3,375 @@ using OffsetArrays
 using Test
 
 @testset "index style" begin
-    @test IndexStyle(CircularArray) == IndexCartesian()
-    @test IndexStyle(CircularVector) == IndexLinear()
+  @test IndexStyle(CircularArray) == IndexCartesian()
+  @test IndexStyle(CircularVector) == IndexLinear()
 end
 
 @testset "construction" begin
-    @testset "construction ($T)" for T = (Float64, Int)
-        data = rand(T,10)
-        arrays = [CircularVector(data), CircularVector{T}(data),
-                CircularArray(data), CircularArray{T}(data), CircularArray{T,1}(data)]
-        @test all(a == first(arrays) for a in arrays)
-        @test all(a isa CircularVector{T,Vector{T}} for a in arrays)
-    end
+  @testset "construction ($T)" for T = (Float64, Int)
+    data = rand(T,10)
+    arrays = [CircularVector(data), CircularVector{T}(data),
+      CircularArray(data), CircularArray{T}(data), CircularArray{T,1}(data)]
+    @test all(a == first(arrays) for a in arrays)
+    @test all(a isa CircularVector{T,Vector{T}} for a in arrays)
+  end
 
-    @testset "matrix construction" begin
-        data = zeros(Float64, 2, 2)
-        ref = CircularMatrix(data)
-        @test CircularArray{Float64, 2}(data) == ref
-        @test CircularMatrix{Float64}(data) == ref
-        @test CircularMatrix{Float64, Array{Float64, 2}}(data) == ref
-        @test CircularMatrix{Float64, Matrix{Float64}}(data) == ref
-    end
+  @testset "matrix construction" begin
+    data = zeros(Float64, 2, 2)
+    ref = CircularMatrix(data)
+    @test CircularArray{Float64, 2}(data) == ref
+    @test CircularMatrix{Float64}(data) == ref
+    @test CircularMatrix{Float64, Array{Float64, 2}}(data) == ref
+    @test CircularMatrix{Float64, Matrix{Float64}}(data) == ref
+  end
 end
 
 @testset "type stability" begin
-    @testset "type stability $(n)d" for n in 1:10
-        a = CircularArray(fill(1, ntuple(_->1, n)))
+  @testset "type stability $(n)d" for n in 1:10
+    a = CircularArray(fill(1, ntuple(_->1, n)))
 
-        @test @inferred(a[1]) isa Int64
-        @test @inferred(a[[1]]) isa CircularVector{Int64}
-        @test @inferred(a[[1]']) isa CircularArray{Int64,2}
-        @test @inferred(axes(a)) isa Tuple{Vararg{AbstractUnitRange}}
-        @test @inferred(similar(a)) isa typeof(a)
-        @test @inferred(similar(a, Float64, Int8.(size(a)))) isa CircularArray{Float64}
-        @test @inferred(similar(typeof(a), axes(a))) isa typeof(a)
-        @test @inferred(a[a]) isa typeof(a)
-    end
+    @test @inferred(a[1]) isa Int64
+    @test @inferred(a[[1]]) isa CircularVector{Int64}
+    @test @inferred(a[[1]']) isa CircularArray{Int64,2}
+    @test @inferred(axes(a)) isa Tuple{Vararg{AbstractUnitRange}}
+    @test @inferred(similar(a)) isa typeof(a)
+    @test @inferred(similar(a, Float64, Int8.(size(a)))) isa CircularArray{Float64}
+    @test @inferred(similar(typeof(a), axes(a))) isa typeof(a)
+    @test @inferred(a[a]) isa typeof(a)
+  end
 end
 
 @testset "display" begin
-    @testset "display $(n)d" for n in 1:3
-        data = rand(Int64, ntuple(_->3, n))
-        v1 = CircularArray(data)
-        io = IOBuffer()
-        io_compare = IOBuffer()
+  @testset "display $(n)d" for n in 1:3
+    data = rand(Int64, ntuple(_->3, n))
+    v1 = CircularArray(data)
+    io = IOBuffer()
+    io_compare = IOBuffer()
 
-        print(io, v1)
-        print(io_compare, data)
-        @test String(take!(io)) == String(take!(io_compare))
+    print(io, v1)
+    print(io_compare, data)
+    @test String(take!(io)) == String(take!(io_compare))
 
-        print(io, summary(v1))
-        print(io_compare, summary(data))
+    print(io, summary(v1))
+    print(io_compare, summary(data))
 
-        text = String(take!(io_compare))
-        text = replace(text, " Vector" => " CircularVector")
-        text = replace(text, " Matrix" => " CircularArray")
-        text = replace(text, " Array" => (n == 1 ? " CircularVector" : " CircularArray"))
-        text = replace(text, r"{.+}" => "(::$(string(typeof(data))))")
-        @test String(take!(io)) == text
-    end
+    text = String(take!(io_compare))
+    text = replace(text, " Vector" => " CircularVector")
+    text = replace(text, " Matrix" => " CircularArray")
+    text = replace(text, " Array" => (n == 1 ? " CircularVector" : " CircularArray"))
+    text = replace(text, r"{.+}" => "(::$(string(typeof(data))))")
+    @test String(take!(io)) == text
+  end
 end
 
 @testset "vector" begin
-    data = rand(Int64, 5)
-    v1 = CircularVector(data)
+  data = rand(Int64, 5)
+  v1 = CircularVector(data)
 
-    @test size(v1, 1) == 5
-    @test parent(v1) == data
-    @test typeof(v1) == CircularVector{Int64,Vector{Int64}}
-    @test isa(v1, CircularVector)
-    @test isa(v1, AbstractVector{Int})
-    @test !isa(v1, AbstractVector{String})
-    @test v1[2] == v1[2 + length(v1)]
+  @test size(v1, 1) == 5
+  @test parent(v1) == data
+  @test typeof(v1) == CircularVector{Int64,Vector{Int64}}
+  @test isa(v1, CircularVector)
+  @test isa(v1, AbstractVector{Int})
+  @test !isa(v1, AbstractVector{String})
+  @test v1[2] == v1[2 + length(v1)]
 
-    @test IndexStyle(v1) == IndexStyle(typeof(v1)) == IndexLinear()
-    @test v1[0] == data[end]
-    @test v1[-4:10] == [data; data; data]
-    @test v1[-3:1][-1] == data[end]
-    @test v1[[true,false,true,false,true]] == v1[[1,3,0]]
-    @test all(e in data for e in v1)
-    @test all(e in v1 for e in data)
+  @test IndexStyle(v1) == IndexStyle(typeof(v1)) == IndexLinear()
+  @test v1[0] == data[end]
+  @test v1[-4:10] == [data; data; data]
+  @test v1[-3:1][-1] == data[end]
+  @test v1[[true,false,true,false,true]] == v1[[1,3,0]]
+  @test all(e in data for e in v1)
+  @test all(e in v1 for e in data)
 
-    v1copy = copy(v1)
-    v1_2 = v1[2]
-    v1[2] = 0
-    v1[3] = 0
-    @test v1[2] == v1[3] == 0
-    @test v1copy[2] == v1_2
-    @test v1copy[7] == v1_2
-    @test_throws MethodError v1[2] = "Hello"
+  v1copy = copy(v1)
+  v1_2 = v1[2]
+  v1[2] = 0
+  v1[3] = 0
+  @test v1[2] == v1[3] == 0
+  @test v1copy[2] == v1_2
+  @test v1copy[7] == v1_2
+  @test_throws MethodError v1[2] = "Hello"
+
+  v2 = CircularVector("abcde", 5)
+
+  @test prod(v2) == "abcde"^5
+
+  @testset "empty/empty!" begin
+    v1 = CircularVector([1,2,3])
+    @test empty(v1) isa CircularVector{Int64}
+    @test empty(v1, Float64) isa CircularVector{Float64}
+    v1 == CircularVector([])
+    # `isempty` can be used to implement `size` method.
+    @test isempty(empty(v1))
 
     v2 = CircularVector("abcde", 5)
+    @test empty!(v2) isa CircularVector{String}
+    @test isempty(v2)
+  end
 
-    @test prod(v2) == "abcde"^5
+  @testset "resize!" begin
+    @test_throws ArgumentError("new length must be ≥ 0") resize!(CircularVector([]), -2)
+    v = CircularVector([1,2,3,4,5,6,7])
+    resize!(v, 3)
+    @test length(v) == 3
 
-    @testset "empty/empty!" begin
-        v1 = CircularVector([1,2,3])
-        @test empty(v1) isa CircularVector{Int64}
-        @test empty(v1, Float64) isa CircularVector{Float64}
-        v1 == CircularVector([])
-        # `isempty` can be used to implement `size` method.
-        @test isempty(empty(v1))
-
-        v2 = CircularVector("abcde", 5)
-        @test empty!(v2) isa CircularVector{String}
-        @test isempty(v2)
+    # ensure defining `resize!` induces `push!` and `append!` methods
+    @testset "push!" begin
+      v = CircularVector([1,2,3])
+      push!(v, 42)
+      @test v == CircularVector([1,2,3,42])
+      push!(v, -9, -99, -999)
+      @test v == CircularVector([1,2,3,42, -9, -99, -999])
     end
 
-    @testset "resize!" begin
-        @test_throws ArgumentError("new length must be ≥ 0") resize!(CircularVector([]), -2)
-        v = CircularVector([1,2,3,4,5,6,7])
-        resize!(v, 3)
-        @test length(v) == 3
+    @testset "append!" begin
+      v1 = CircularVector([1,2,3])
+      append!(v1, [-9, -99, -999])
+      @test v1 == CircularVector([1,2,3, -9, -99, -999])
 
-        # ensure defining `resize!` induces `push!` and `append!` methods
-        @testset "push!" begin
-            v = CircularVector([1,2,3])
-            push!(v, 42)
-            @test v == CircularVector([1,2,3,42])
-            push!(v, -9, -99, -999)
-            @test v == CircularVector([1,2,3,42, -9, -99, -999])
-        end
+      v2 = CircularVector([1,2,3])
+      append!(v2, CircularVector([-1,-2]))
+      @test v2 == CircularVector([1,2,3,-1,-2])
 
-        @testset "append!" begin
-            v1 = CircularVector([1,2,3])
-            append!(v1, [-9, -99, -999])
-            @test v1 == CircularVector([1,2,3, -9, -99, -999])
+      v3 = CircularVector([1,2,3])
+      append!(v3, [4, 5], [6])
+      @test v3 == CircularVector([1,2,3,4,5,6])
 
-            v2 = CircularVector([1,2,3])
-            append!(v2, CircularVector([-1,-2]))
-            @test v2 == CircularVector([1,2,3,-1,-2])
+      v4 = CircularVector([1,2,3])
+      o4 = OffsetVector([-1,-2,-3], -2:0)
+      append!(v4, o4)
+      @test v4 == CircularVector([1,2,3,-1,-2,-3])
 
-            v3 = CircularVector([1,2,3])
-            append!(v3, [4, 5], [6])
-            @test v3 == CircularVector([1,2,3,4,5,6])
-
-            v4 = CircularVector([1,2,3])
-            o4 = OffsetVector([-1,-2,-3], -2:0)
-            append!(v4, o4)
-            @test v4 == CircularVector([1,2,3,-1,-2,-3])
-
-            v5 = CircularVector([1,2,3])
-            o5 = OffsetVector([-1,-2,-3], -2:0)
-            append!(v5, o5, -4)
-            @test v5 == CircularVector([1,2,3,-1,-2,-3,-4])
-        end
+      v5 = CircularVector([1,2,3])
+      o5 = OffsetVector([-1,-2,-3], -2:0)
+      append!(v5, o5, -4)
+      @test v5 == CircularVector([1,2,3,-1,-2,-3,-4])
     end
+  end
 
-    @testset "pop!" begin
-        v1 = CircularVector([1,2,3,42])
-        pop!(v1) == 42
-        @test v1 == CircularVector([1,2,3])
+  @testset "pop!" begin
+    v1 = CircularVector([1,2,3,42])
+    pop!(v1) == 42
+    @test v1 == CircularVector([1,2,3])
 
-        v2 = CircularVector([1])
-        pop!(v2) == 1
-        @test v2 == CircularVector([])
-        @test isempty(v2)
-        @test_throws ArgumentError("array must be non-empty") pop!(v2)
-    end
+    v2 = CircularVector([1])
+    pop!(v2) == 1
+    @test v2 == CircularVector([])
+    @test isempty(v2)
+    @test_throws ArgumentError("array must be non-empty") pop!(v2)
+  end
 
-    @testset "sizehint!" begin
-        v = CircularVector([1,2,3,4,5,6,7])
-        resize!(v, 1)
-        sizehint!(v, 1)
-        @test length(v) == 1
-    end
+  @testset "sizehint!" begin
+    v = CircularVector([1,2,3,4,5,6,7])
+    resize!(v, 1)
+    sizehint!(v, 1)
+    @test length(v) == 1
+  end
 
-    @testset "deleteat!" begin
-        @test deleteat!(CircularVector([1, 2, 3]), 2) == CircularVector([1, 3])
-        @test deleteat!(CircularVector([1, 2, 3]), 5) == CircularVector([1, 3])
-        @test deleteat!(CircularVector([1, 2, 3]), 4) == CircularVector([2, 3])
-        @test deleteat!(CircularVector([1, 2, 3]), 0) == CircularVector([1, 2])
-        @test deleteat!(CircularVector([1, 2, 3, 4]), 1:5:10) == CircularVector([3, 4])
-        @test deleteat!(CircularVector([1, 2, 3, 4]), [1, 5]) == CircularVector([2, 3, 4])
-        @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5)) == CircularVector([2, 3, 4])
-        @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 6)) == CircularVector([3, 4])
-        @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 3, 5)) == CircularVector([2, 4])
-        @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5, 7)) == CircularVector([2, 4])
-    end
+  @testset "deleteat!" begin
+    @test deleteat!(CircularVector([1, 2, 3]), 2) == CircularVector([1, 3])
+    @test deleteat!(CircularVector([1, 2, 3]), 5) == CircularVector([1, 3])
+    @test deleteat!(CircularVector([1, 2, 3]), 4) == CircularVector([2, 3])
+    @test deleteat!(CircularVector([1, 2, 3]), 0) == CircularVector([1, 2])
+    @test deleteat!(CircularVector([1, 2, 3, 4]), 1:5:10) == CircularVector([3, 4])
+    @test deleteat!(CircularVector([1, 2, 3, 4]), [1, 5]) == CircularVector([2, 3, 4])
+    @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5)) == CircularVector([2, 3, 4])
+    @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 6)) == CircularVector([3, 4])
+    @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 3, 5)) == CircularVector([2, 4])
+    @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5, 7)) == CircularVector([2, 4])
+  end
 
-    @testset "insert!" begin
-        @test insert!(CircularVector([1, 2, 3]), 2, 4) == CircularVector([1, 4, 2, 3])
-        @test insert!(CircularVector([1, 2, 3]), 5, 4) == CircularVector([1, 4, 2, 3])
-        @test insert!(CircularVector([1, 2, 3]), 4, 4) == CircularVector([4, 1, 2, 3])
-        @test insert!(CircularVector([1, 2, 3]), 0, 4) == CircularVector([1, 2, 4, 3])
-    end
+  @testset "insert!" begin
+    @test insert!(CircularVector([1, 2, 3]), 2, 4) == CircularVector([1, 4, 2, 3])
+    @test insert!(CircularVector([1, 2, 3]), 5, 4) == CircularVector([1, 4, 2, 3])
+    @test insert!(CircularVector([1, 2, 3]), 4, 4) == CircularVector([4, 1, 2, 3])
+    @test insert!(CircularVector([1, 2, 3]), 0, 4) == CircularVector([1, 2, 4, 3])
+  end
+  @testset "splice!" begin
+    @test splice!(CircularVector([1, 2, 3]), 2) == 2
+    @test splice!(CircularVector([1, 2, 3]), 5) == 2
+    @test splice!(CircularVector([1, 2, 3]), 4) == 1
+    @test splice!(CircularVector([1, 2, 3]), 0) == 3
+    @test splice!(CircularVector([1, 2, 3]), [2, 3]) == [2, 3]
 
-    @testset "doubly circular" begin
-        a = CircularVector([1, 2, 3, 4, 5])
-        b = CircularVector(a)
+    v = CircularVector([1, 2, 3, 4])
+    spliced = splice!(v, 2:3, [42, 43])
+    @test spliced == CircularVector([2, 3])
+    @test v == CircularVector([1, 42, 43, 4])
 
-        @test all(a[i] == b[i] for i in -50:50)
-    end
+    v = CircularVector([1, 2, 3, 4])
+    spliced = splice!(v, 3:2, [42, 43])
+    @test length(spliced) == 0
+    @test v == CircularVector([1, 2, 42, 43, 3, 4])
 
-    @testset "type stability" begin
-        v3 = @inferred(map(x -> x+1, CircularArray([1, 2, 3, 4])))
-        @test v3 isa CircularVector{Int64}
-        @test v3 == CircularArray([2, 3, 4, 5])
-        @test similar(v3, Base.OneTo(4)) isa typeof(v3)
-        @test similar(typeof(v3), Base.OneTo(4)) isa typeof(v3)
-        @test similar(typeof(v3), 4) isa typeof(v3)
-        @test similar(typeof(v3), 4) isa typeof(v3)
+    v1 = CircularVector([1, 2, 3, 4])
+    spliced1 = splice!(v1, 5:7, [42, 43])
+    v2 = CircularVector([1, 2, 3, 4])
+    spliced2 = splice!(v2, 1:3, [42, 43])
+    t = Vector([1, 2, 3, 4])
+    spliced3 = splice!(t, 1:3, [42, 43])
+    @test spliced3 == [1, 2, 3]
 
-        v4 = @inferred(CircularArray([1, 2, 3, 4]) .+ 1)
-        @test v4 isa CircularVector{Int64}
-        @test v4 == CircularArray([2, 3, 4, 5])
+    @test spliced1 == CircularVector([1, 2, 3])
+    @test spliced1 == spliced2
+    @test v1 == v2
+    @test v1 == t
 
-        v5 = v4 .> 3
-        @test v5 isa CircularVector{Bool, BitVector}
-        @test v5 == CircularArray([0, 0, 1, 1])
-    end
+    v = CircularVector([1, 2, 3, 4])
+    spliced = splice!(v, 5:4, [42, 43])
+    @test length(spliced) == 0
+    @test v == CircularVector([42, 43, 1, 2, 3, 4])
+  end
+
+  @testset "doubly circular" begin
+    a = CircularVector([1, 2, 3, 4, 5])
+    b = CircularVector(a)
+
+    @test all(a[i] == b[i] for i in -50:50)
+  end
+
+  @testset "type stability" begin
+    v3 = @inferred(map(x -> x+1, CircularArray([1, 2, 3, 4])))
+    @test v3 isa CircularVector{Int64}
+    @test v3 == CircularArray([2, 3, 4, 5])
+    @test similar(v3, Base.OneTo(4)) isa typeof(v3)
+    @test similar(typeof(v3), Base.OneTo(4)) isa typeof(v3)
+    @test similar(typeof(v3), 4) isa typeof(v3)
+    @test similar(typeof(v3), 4) isa typeof(v3)
+
+    v4 = @inferred(CircularArray([1, 2, 3, 4]) .+ 1)
+    @test v4 isa CircularVector{Int64}
+    @test v4 == CircularArray([2, 3, 4, 5])
+
+    v5 = v4 .> 3
+    @test v5 isa CircularVector{Bool, BitVector}
+    @test v5 == CircularArray([0, 0, 1, 1])
+  end
 end
 
 @testset "matrix" begin
-    b_arr = [2 4 6 8; 10 12 14 16; 18 20 22 24]
-    a1 = CircularMatrix(b_arr)
-    @test size(a1) == (3, 4)
-    @test parent(a1) == b_arr
+  b_arr = [2 4 6 8; 10 12 14 16; 18 20 22 24]
+  a1 = CircularMatrix(b_arr)
+  @test size(a1) == (3, 4)
+  @test parent(a1) == b_arr
 
-    @test a1[2, 3] == 14
-    @test a1[2, Int32(3)] == 14
-    a1[2, 3] = 17
-    @test a1[2, 3] == 17
-    @test a1[-1, 7] == 17
-    @test a1[CartesianIndex(-1, 7)] == 17
-    @test a1[-1:5, 4:10][1, 4] == 17
-    @test a1[:, -1:-1][2, 1] == 17
-    a1[CartesianIndex(-2, 7)] = 99
-    @test a1[1, 3] == 99
+  @test a1[2, 3] == 14
+  @test a1[2, Int32(3)] == 14
+  a1[2, 3] = 17
+  @test a1[2, 3] == 17
+  @test a1[-1, 7] == 17
+  @test a1[CartesianIndex(-1, 7)] == 17
+  @test a1[-1:5, 4:10][1, 4] == 17
+  @test a1[:, -1:-1][2, 1] == 17
+  a1[CartesianIndex(-2, 7)] = 99
+  @test a1[1, 3] == 99
 
-    a1[18] = 9
-    @test a1[18] == a1[-6] == a1[6] == a1[3,2] == a1[0,6] == b_arr[3,2] == b_arr[6] == 9
+  a1[18] = 9
+  @test a1[18] == a1[-6] == a1[6] == a1[3,2] == a1[0,6] == b_arr[3,2] == b_arr[6] == 9
 
-    @test IndexStyle(a1) == IndexStyle(typeof(a1)) == IndexCartesian()
-    @test a1[3] == a1[3,1]
-    @test a1[Int32(4)] == a1[1,2]
-    @test a1[-1] == a1[length(a1)-1]
+  @test IndexStyle(a1) == IndexStyle(typeof(a1)) == IndexCartesian()
+  @test a1[3] == a1[3,1]
+  @test a1[Int32(4)] == a1[1,2]
+  @test a1[-1] == a1[length(a1)-1]
 
-    @test a1[2, 3, 1] == 17 # trailing index
-    @test a1[2, 3, 99] == 17
-    @test a1[2, 3, :] == [17]
+  @test a1[2, 3, 1] == 17 # trailing index
+  @test a1[2, 3, 99] == 17
+  @test a1[2, 3, :] == [17]
 
-    @test !isa(a1, CircularVector)
-    @test !isa(a1, AbstractVector)
-    @test isa(a1, AbstractMatrix)
-    @test isa(a1, AbstractArray)
+  @test !isa(a1, CircularVector)
+  @test !isa(a1, AbstractVector)
+  @test isa(a1, AbstractMatrix)
+  @test isa(a1, AbstractArray)
 
-    @test size(reshape(a1, (2, 2, 3))) == (2, 2, 3)
+  @test size(reshape(a1, (2, 2, 3))) == (2, 2, 3)
 
-    a2 = CircularMatrix(4, (2, 3))
-    @test isa(a2, CircularMatrix{Int})
-    @test isa(a2, CircularArray{Int, 2})
+  a2 = CircularMatrix(4, (2, 3))
+  @test isa(a2, CircularMatrix{Int})
+  @test isa(a2, CircularArray{Int, 2})
 
-    a3 = @inferred(a2 .+ 1)
-    @test a3 isa CircularMatrix{Int64}
-    @test a3 isa CircularArray{Int64, 2}
-    @test a3 == CircularArray(5, (2, 3))
+  a3 = @inferred(a2 .+ 1)
+  @test a3 isa CircularMatrix{Int64}
+  @test a3 isa CircularArray{Int64, 2}
+  @test a3 == CircularArray(5, (2, 3))
 
-    @testset "doubly circular" begin
-        a = CircularMatrix(b_arr)
-        da = CircularMatrix(a)
+  @testset "doubly circular" begin
+    a = CircularMatrix(b_arr)
+    da = CircularMatrix(a)
 
-        @test da isa CircularMatrix
-        @test all(a[i, j] == da[i, j] for i in -8:8, j in -8:8)
-        @test all(a[i] == da[i] for i in -50:50)
-    end
+    @test da isa CircularMatrix
+    @test all(a[i, j] == da[i, j] for i in -8:8, j in -8:8)
+    @test all(a[i] == da[i] for i in -50:50)
+  end
 end
 
 @testset "3-array" begin
-    t3 = collect(reshape('a':'x', 2,3,4))
-    c3 = CircularArray(t3)
+  t3 = collect(reshape('a':'x', 2,3,4))
+  c3 = CircularArray(t3)
 
-    @test parent(c3) == t3
+  @test parent(c3) == t3
 
-    @test c3[1,3,3] == c3[3,3,3] == c3[3,3,7] == c3[3,3,7,1]
+  @test c3[1,3,3] == c3[3,3,3] == c3[3,3,7] == c3[3,3,7,1]
 
-    c3[3,3,7] = 'Z'
-    @test t3[1,3,3] == 'Z'
+  c3[3,3,7] = 'Z'
+  @test t3[1,3,3] == 'Z'
 
-    @test c3[3, CartesianIndex(3,7)] == 'Z'
-    c3[Int32(3), CartesianIndex(3,7)] = 'ζ'
-    @test t3[1,3,3] == 'ζ'
+  @test c3[3, CartesianIndex(3,7)] == 'Z'
+  c3[Int32(3), CartesianIndex(3,7)] = 'ζ'
+  @test t3[1,3,3] == 'ζ'
 
-    c3[34] = 'J'
-    @test c3[34] == c3[-38] == c3[10] == c3[2,2,2] == c3[4,5,6] == t3[2,2,2] == t3[10] == 'J'
+  c3[34] = 'J'
+  @test c3[34] == c3[-38] == c3[10] == c3[2,2,2] == c3[4,5,6] == t3[2,2,2] == t3[10] == 'J'
 
-    @test vec(c3[:, [CartesianIndex()], 1, 5]) == vec(t3[:, 1, 1])
+  @test vec(c3[:, [CartesianIndex()], 1, 5]) == vec(t3[:, 1, 1])
 
-    @test IndexStyle(c3) == IndexStyle(typeof(c3)) == IndexCartesian()
-    @test c3[-1] == t3[length(t3)-1]
+  @test IndexStyle(c3) == IndexStyle(typeof(c3)) == IndexCartesian()
+  @test c3[-1] == t3[length(t3)-1]
 
-    @test_throws BoundsError c3[2,3] # too few indices
-    @test_throws BoundsError c3[CartesianIndex(2,3)]
+  @test_throws BoundsError c3[2,3] # too few indices
+  @test_throws BoundsError c3[CartesianIndex(2,3)]
 
-    @testset "doubly circular" begin
-        c = CircularArray(t3)
-        dc = CircularArray(c)
+  @testset "doubly circular" begin
+    c = CircularArray(t3)
+    dc = CircularArray(c)
 
-        @test all(c[i, j, k] == dc[i, j, k] for i in -5:5, j in -5:5, k in -5:5)
-        @test all(c[i] == dc[i] for i in -50:50)
-    end
+    @test all(c[i, j, k] == dc[i, j, k] for i in -5:5, j in -5:5, k in -5:5)
+    @test all(c[i] == dc[i] for i in -50:50)
+  end
 end
 
 @testset "offset indices" begin
-    i = OffsetArray(1:5,-3)
-    a = CircularArray(i)
-    @test axes(a) == axes(i)
-    @test a[1] == 4
-    @test a[10] == a[-10] == a[0] == 3
-    @test a[-2:7] == [1:5; 1:5]
-    @test a[0:9] == [3:5; 1:5; 1:2]
-    @test a[1:10][-10] == 3
-    @test a[i] == OffsetArray([4,5,1,2,3],-3)
+  i = OffsetArray(1:5,-3)
+  a = CircularArray(i)
+  @test axes(a) == axes(i)
+  @test a[1] == 4
+  @test a[10] == a[-10] == a[0] == 3
+  @test a[-2:7] == [1:5; 1:5]
+  @test a[0:9] == [3:5; 1:5; 1:2]
+  @test a[1:10][-10] == 3
+  @test a[i] == OffsetArray([4,5,1,2,3],-3)
 
-    @testset "type stability" begin
-        @test @inferred(similar(a)) isa CircularVector
-        @test @inferred(similar(typeof(a), axes(a))) isa CircularVector
+  @testset "type stability" begin
+    @test @inferred(similar(a)) isa CircularVector
+    @test @inferred(similar(typeof(a), axes(a))) isa CircularVector
 
-        b = CircularVector([1, 2, 3, 4, 5])
-        @test @inferred(similar(b, 3:5)) isa CircularVector
-        @test @inferred(similar(typeof(b), 3:5)) isa CircularVector
-    end
+    b = CircularVector([1, 2, 3, 4, 5])
+    @test @inferred(similar(b, 3:5)) isa CircularVector
+    @test @inferred(similar(typeof(b), 3:5)) isa CircularVector
+  end
 
-    circ_a = circshift(a,3)
-    @test axes(circ_a) == axes(a)
-    @test circ_a[1:5] == 1:5
+  circ_a = circshift(a,3)
+  @test axes(circ_a) == axes(a)
+  @test circ_a[1:5] == 1:5
 
-    j = OffsetArray([true,false,true],1)
-    @test a[j] == [5,2]
+  j = OffsetArray([true,false,true],1)
+  @test a[j] == [5,2]
 
-    data = reshape(1:9,3,3)
-    a = CircularArray(OffsetArray(data,-1,-1))
-    @test collect(a) == data
-    @test all(a[x,y] == data[mod1(x+1,3),mod1(y+1,3)] for x=-10:10, y=-10:10)
-    @test a[i,1] == CircularArray(OffsetArray([5,6,4,5,6],-2:2))
-    @test a[CartesianIndex.(i,i)] == CircularArray(OffsetArray([5,9,1,5,9],-2:2))
-    @test a[a .> 4] == 5:9
+  data = reshape(1:9,3,3)
+  a = CircularArray(OffsetArray(data,-1,-1))
+  @test collect(a) == data
+  @test all(a[x,y] == data[mod1(x+1,3),mod1(y+1,3)] for x=-10:10, y=-10:10)
+  @test a[i,1] == CircularArray(OffsetArray([5,6,4,5,6],-2:2))
+  @test a[CartesianIndex.(i,i)] == CircularArray(OffsetArray([5,9,1,5,9],-2:2))
+  @test a[a .> 4] == 5:9
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -193,30 +193,37 @@ end
         @test splice!(CircularVector([1, 2, 3]), 5) == 2
         @test splice!(CircularVector([1, 2, 3]), 4) == 1
         @test splice!(CircularVector([1, 2, 3]), 0) == 3
+        v = CircularVector([1, 2, 3])
+        spliced = splice!(v, 2)
+        @test spliced == 2
+        @test v == CircularVector([1, 3])
         @test splice!(CircularVector([1, 2, 3]), [2, 3]) == [2, 3]
 
         v = CircularVector([1, 2, 3, 4])
-        spliced = splice!(v, 2:3, [42, 43])
-        @test spliced == CircularVector([2, 3])
-        @test v == CircularVector([1, 42, 43, 4])
+        spliced = splice!(v, 2:4, [42, 43])
+        @test spliced == CircularVector([2, 3, 4])
+        @test v == CircularVector([1, 42, 43])
+
+        v = CircularVector([1, 2, 3, 4])
+        spliced = splice!(v, 3:3)
+        @test length(spliced) == 1
+        @test spliced == CircularVector([3])
+        @test length(v) == 3
 
         v = CircularVector([1, 2, 3, 4])
         spliced = splice!(v, 3:2, [42, 43])
         @test length(spliced) == 0
         @test v == CircularVector([1, 2, 42, 43, 3, 4])
 
+        # correctness test for modulo unit ranges
         v1 = CircularVector([1, 2, 3, 4])
         spliced1 = splice!(v1, 5:7, [42, 43])
         v2 = CircularVector([1, 2, 3, 4])
         spliced2 = splice!(v2, 1:3, [42, 43])
-        t = Vector([1, 2, 3, 4])
-        spliced3 = splice!(t, 1:3, [42, 43])
-        @test spliced3 == [1, 2, 3]
 
-        @test spliced1 == CircularVector([1, 2, 3])
-        @test spliced1 == spliced2
         @test v1 == v2
-        @test v1 == t
+        @test spliced1 == spliced2 == [1, 2, 3]
+        @test v1 == v2
 
         v = CircularVector([1, 2, 3, 4])
         spliced = splice!(v, 5:4, [42, 43])
@@ -247,6 +254,12 @@ end
         v5 = v4 .> 3
         @test v5 isa CircularVector{Bool, BitVector}
         @test v5 == CircularArray([0, 0, 1, 1])
+
+        @inferred splice!(CircularVector([1, 2, 3, 4]), 1, [42, 43])
+        @inferred splice!(CircularVector([1, 2, 3, 4]), 5, [42, 43])
+        @inferred splice!(CircularVector([1, 2, 3, 4]), 5:7, [42, 43])
+        @inferred splice!(CircularVector([1, 2, 3, 4]), 3:2, [42, 43])
+        @inferred splice!(CircularVector([1, 2, 3, 4]), [1, 2, 3])
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,58 +9,58 @@ end
 
 @testset "construction" begin
     @testset "construction ($T)" for T = (Float64, Int)
-      data = rand(T,10)
-      arrays = [CircularVector(data), CircularVector{T}(data),
-              CircularArray(data), CircularArray{T}(data), CircularArray{T,1}(data)]
-      @test all(a == first(arrays) for a in arrays)
-      @test all(a isa CircularVector{T,Vector{T}} for a in arrays)
+        data = rand(T,10)
+        arrays = [CircularVector(data), CircularVector{T}(data),
+                CircularArray(data), CircularArray{T}(data), CircularArray{T,1}(data)]
+        @test all(a == first(arrays) for a in arrays)
+        @test all(a isa CircularVector{T,Vector{T}} for a in arrays)
     end
 
     @testset "matrix construction" begin
-      data = zeros(Float64, 2, 2)
-      ref = CircularMatrix(data)
-      @test CircularArray{Float64, 2}(data) == ref
-      @test CircularMatrix{Float64}(data) == ref
-      @test CircularMatrix{Float64, Array{Float64, 2}}(data) == ref
-      @test CircularMatrix{Float64, Matrix{Float64}}(data) == ref
+        data = zeros(Float64, 2, 2)
+        ref = CircularMatrix(data)
+        @test CircularArray{Float64, 2}(data) == ref
+        @test CircularMatrix{Float64}(data) == ref
+        @test CircularMatrix{Float64, Array{Float64, 2}}(data) == ref
+        @test CircularMatrix{Float64, Matrix{Float64}}(data) == ref
     end
 end
 
 @testset "type stability" begin
     @testset "type stability $(n)d" for n in 1:10
-      a = CircularArray(fill(1, ntuple(_->1, n)))
+        a = CircularArray(fill(1, ntuple(_->1, n)))
 
-      @test @inferred(a[1]) isa Int64
-      @test @inferred(a[[1]]) isa CircularVector{Int64}
-      @test @inferred(a[[1]']) isa CircularArray{Int64,2}
-      @test @inferred(axes(a)) isa Tuple{Vararg{AbstractUnitRange}}
-      @test @inferred(similar(a)) isa typeof(a)
-      @test @inferred(similar(a, Float64, Int8.(size(a)))) isa CircularArray{Float64}
-      @test @inferred(similar(typeof(a), axes(a))) isa typeof(a)
-      @test @inferred(a[a]) isa typeof(a)
+        @test @inferred(a[1]) isa Int64
+        @test @inferred(a[[1]]) isa CircularVector{Int64}
+        @test @inferred(a[[1]']) isa CircularArray{Int64,2}
+        @test @inferred(axes(a)) isa Tuple{Vararg{AbstractUnitRange}}
+        @test @inferred(similar(a)) isa typeof(a)
+        @test @inferred(similar(a, Float64, Int8.(size(a)))) isa CircularArray{Float64}
+        @test @inferred(similar(typeof(a), axes(a))) isa typeof(a)
+        @test @inferred(a[a]) isa typeof(a)
     end
 end
 
 @testset "display" begin
     @testset "display $(n)d" for n in 1:3
-      data = rand(Int64, ntuple(_->3, n))
-      v1 = CircularArray(data)
-      io = IOBuffer()
-      io_compare = IOBuffer()
+        data = rand(Int64, ntuple(_->3, n))
+        v1 = CircularArray(data)
+        io = IOBuffer()
+        io_compare = IOBuffer()
 
-      print(io, v1)
-      print(io_compare, data)
-      @test String(take!(io)) == String(take!(io_compare))
+        print(io, v1)
+        print(io_compare, data)
+        @test String(take!(io)) == String(take!(io_compare))
 
-      print(io, summary(v1))
-      print(io_compare, summary(data))
+        print(io, summary(v1))
+        print(io_compare, summary(data))
 
-      text = String(take!(io_compare))
-      text = replace(text, " Vector" => " CircularVector")
-      text = replace(text, " Matrix" => " CircularArray")
-      text = replace(text, " Array" => (n == 1 ? " CircularVector" : " CircularArray"))
-      text = replace(text, r"{.+}" => "(::$(string(typeof(data))))")
-      @test String(take!(io)) == text
+        text = String(take!(io_compare))
+        text = replace(text, " Vector" => " CircularVector")
+        text = replace(text, " Matrix" => " CircularArray")
+        text = replace(text, " Array" => (n == 1 ? " CircularVector" : " CircularArray"))
+        text = replace(text, r"{.+}" => "(::$(string(typeof(data))))")
+        @test String(take!(io)) == text
     end
 end
 
@@ -98,155 +98,194 @@ end
     @test prod(v2) == "abcde"^5
 
     @testset "empty/empty!" begin
-      v1 = CircularVector([1,2,3])
-      @test empty(v1) isa CircularVector{Int64}
-      @test empty(v1, Float64) isa CircularVector{Float64}
-      v1 == CircularVector([])
-      # `isempty` can be used to implement `size` method.
-      @test isempty(empty(v1))
+        v1 = CircularVector([1,2,3])
+        @test empty(v1) isa CircularVector{Int64}
+        @test empty(v1, Float64) isa CircularVector{Float64}
+        v1 == CircularVector([])
+        # `isempty` can be used to implement `size` method.
+        @test isempty(empty(v1))
 
-      v2 = CircularVector("abcde", 5)
-      @test empty!(v2) isa CircularVector{String}
-      @test isempty(v2)
+        v2 = CircularVector("abcde", 5)
+        @test empty!(v2) isa CircularVector{String}
+        @test isempty(v2)
     end
 
     @testset "resize!" begin
-      @test_throws ArgumentError("new length must be ≥ 0") resize!(CircularVector([]), -2)
-      v = CircularVector([1,2,3,4,5,6,7])
-      resize!(v, 3)
-      @test length(v) == 3
+        @test_throws ArgumentError("new length must be ≥ 0") resize!(CircularVector([]), -2)
+        v = CircularVector([1,2,3,4,5,6,7])
+        resize!(v, 3)
+        @test length(v) == 3
 
-      # ensure defining `resize!` induces `push!` and `append!` methods
-      @testset "push!" begin
-        v = CircularVector([1,2,3])
-        push!(v, 42)
-        @test v == CircularVector([1,2,3,42])
-        push!(v, -9, -99, -999)
-        @test v == CircularVector([1,2,3,42, -9, -99, -999])
-      end
+        # ensure defining `resize!` induces `push!` and `append!` methods
+        @testset "push!" begin
+            v = CircularVector([1,2,3])
+            push!(v, 42)
+            @test v == CircularVector([1,2,3,42])
+            push!(v, -9, -99, -999)
+            @test v == CircularVector([1,2,3,42, -9, -99, -999])
+        end
 
-      @testset "append!" begin
-        v1 = CircularVector([1,2,3])
-        append!(v1, [-9, -99, -999])
-        @test v1 == CircularVector([1,2,3, -9, -99, -999])
+        @testset "append!" begin
+            v1 = CircularVector([1,2,3])
+            append!(v1, [-9, -99, -999])
+            @test v1 == CircularVector([1,2,3, -9, -99, -999])
 
-        v2 = CircularVector([1,2,3])
-        append!(v2, CircularVector([-1,-2]))
-        @test v2 == CircularVector([1,2,3,-1,-2])
+            v2 = CircularVector([1,2,3])
+            append!(v2, CircularVector([-1,-2]))
+            @test v2 == CircularVector([1,2,3,-1,-2])
 
-        v3 = CircularVector([1,2,3])
-        append!(v3, [4, 5], [6])
-        @test v3 == CircularVector([1,2,3,4,5,6])
+            v3 = CircularVector([1,2,3])
+            append!(v3, [4, 5], [6])
+            @test v3 == CircularVector([1,2,3,4,5,6])
 
-        v4 = CircularVector([1,2,3])
-        o4 = OffsetVector([-1,-2,-3], -2:0)
-        append!(v4, o4)
-        @test v4 == CircularVector([1,2,3,-1,-2,-3])
+            v4 = CircularVector([1,2,3])
+            o4 = OffsetVector([-1,-2,-3], -2:0)
+            append!(v4, o4)
+            @test v4 == CircularVector([1,2,3,-1,-2,-3])
 
-        v5 = CircularVector([1,2,3])
-        o5 = OffsetVector([-1,-2,-3], -2:0)
-        append!(v5, o5, -4)
-        @test v5 == CircularVector([1,2,3,-1,-2,-3,-4])
-      end
+            v5 = CircularVector([1,2,3])
+            o5 = OffsetVector([-1,-2,-3], -2:0)
+            append!(v5, o5, -4)
+            @test v5 == CircularVector([1,2,3,-1,-2,-3,-4])
+        end
+    end
+    @testset "resize!" begin
+        @test_throws ArgumentError("new length must be ≥ 0") resize!(CircularVector([]), -2)
+        v = CircularVector([1,2,3,4,5,6,7])
+        resize!(v, 3)
+        @test length(v) == 3
+
+        # ensure defining `resize!` induces `push!` and `append!` methods
+        @testset "push!" begin
+            v = CircularVector([1,2,3])
+            push!(v, 42)
+            @test v == CircularVector([1,2,3,42])
+            push!(v, -9, -99, -999)
+            @test v == CircularVector([1,2,3,42, -9, -99, -999])
+        end
+
+        @testset "append!" begin
+            v1 = CircularVector([1,2,3])
+            append!(v1, [-9, -99, -999])
+            @test v1 == CircularVector([1,2,3, -9, -99, -999])
+
+            v2 = CircularVector([1,2,3])
+            append!(v2, CircularVector([-1,-2]))
+            @test v2 == CircularVector([1,2,3,-1,-2])
+
+            v3 = CircularVector([1,2,3])
+            append!(v3, [4, 5], [6])
+            @test v3 == CircularVector([1,2,3,4,5,6])
+
+            v4 = CircularVector([1,2,3])
+            o4 = OffsetVector([-1,-2,-3], -2:0)
+            append!(v4, o4)
+            @test v4 == CircularVector([1,2,3,-1,-2,-3])
+
+            v5 = CircularVector([1,2,3])
+            o5 = OffsetVector([-1,-2,-3], -2:0)
+            append!(v5, o5, -4)
+            @test v5 == CircularVector([1,2,3,-1,-2,-3,-4])
+        end
     end
 
     @testset "pop!" begin
-      v1 = CircularVector([1,2,3,42])
-      pop!(v1) == 42
-      @test v1 == CircularVector([1,2,3])
+        v1 = CircularVector([1,2,3,42])
+        pop!(v1) == 42
+        @test v1 == CircularVector([1,2,3])
 
-      v2 = CircularVector([1])
-      pop!(v2) == 1
-      @test v2 == CircularVector([])
-      @test isempty(v2)
-      @test_throws ArgumentError("array must be non-empty") pop!(v2)
+        v2 = CircularVector([1])
+        pop!(v2) == 1
+        @test v2 == CircularVector([])
+        @test isempty(v2)
+        @test_throws ArgumentError("array must be non-empty") pop!(v2)
     end
 
     @testset "sizehint!" begin
-      v = CircularVector([1,2,3,4,5,6,7])
-      resize!(v, 1)
-      sizehint!(v, 1)
-      @test length(v) == 1
+        v = CircularVector([1,2,3,4,5,6,7])
+        resize!(v, 1)
+        sizehint!(v, 1)
+        @test length(v) == 1
     end
 
     @testset "deleteat!" begin
-      @test deleteat!(CircularVector([1, 2, 3]), 2) == CircularVector([1, 3])
-      @test deleteat!(CircularVector([1, 2, 3]), 5) == CircularVector([1, 3])
-      @test deleteat!(CircularVector([1, 2, 3]), 4) == CircularVector([2, 3])
-      @test deleteat!(CircularVector([1, 2, 3]), 0) == CircularVector([1, 2])
-      @test deleteat!(CircularVector([1, 2, 3, 4]), 1:5:10) == CircularVector([3, 4])
-      @test deleteat!(CircularVector([1, 2, 3, 4]), [1, 5]) == CircularVector([2, 3, 4])
-      @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5)) == CircularVector([2, 3, 4])
-      @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 6)) == CircularVector([3, 4])
-      @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 3, 5)) == CircularVector([2, 4])
-      @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5, 7)) == CircularVector([2, 4])
+        @test deleteat!(CircularVector([1, 2, 3]), 2) == CircularVector([1, 3])
+        @test deleteat!(CircularVector([1, 2, 3]), 5) == CircularVector([1, 3])
+        @test deleteat!(CircularVector([1, 2, 3]), 4) == CircularVector([2, 3])
+        @test deleteat!(CircularVector([1, 2, 3]), 0) == CircularVector([1, 2])
+        @test deleteat!(CircularVector([1, 2, 3, 4]), 1:5:10) == CircularVector([3, 4])
+        @test deleteat!(CircularVector([1, 2, 3, 4]), [1, 5]) == CircularVector([2, 3, 4])
+        @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5)) == CircularVector([2, 3, 4])
+        @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 6)) == CircularVector([3, 4])
+        @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 3, 5)) == CircularVector([2, 4])
+        @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5, 7)) == CircularVector([2, 4])
     end
 
     @testset "insert!" begin
-      @test insert!(CircularVector([1, 2, 3]), 2, 4) == CircularVector([1, 4, 2, 3])
-      @test insert!(CircularVector([1, 2, 3]), 5, 4) == CircularVector([1, 4, 2, 3])
-      @test insert!(CircularVector([1, 2, 3]), 4, 4) == CircularVector([4, 1, 2, 3])
-      @test insert!(CircularVector([1, 2, 3]), 0, 4) == CircularVector([1, 2, 4, 3])
+        @test insert!(CircularVector([1, 2, 3]), 2, 4) == CircularVector([1, 4, 2, 3])
+        @test insert!(CircularVector([1, 2, 3]), 5, 4) == CircularVector([1, 4, 2, 3])
+        @test insert!(CircularVector([1, 2, 3]), 4, 4) == CircularVector([4, 1, 2, 3])
+        @test insert!(CircularVector([1, 2, 3]), 0, 4) == CircularVector([1, 2, 4, 3])
     end
     @testset "splice!" begin
-      @test splice!(CircularVector([1, 2, 3]), 2) == 2
-      @test splice!(CircularVector([1, 2, 3]), 5) == 2
-      @test splice!(CircularVector([1, 2, 3]), 4) == 1
-      @test splice!(CircularVector([1, 2, 3]), 0) == 3
-      @test splice!(CircularVector([1, 2, 3]), [2, 3]) == [2, 3]
+        @test splice!(CircularVector([1, 2, 3]), 2) == 2
+        @test splice!(CircularVector([1, 2, 3]), 5) == 2
+        @test splice!(CircularVector([1, 2, 3]), 4) == 1
+        @test splice!(CircularVector([1, 2, 3]), 0) == 3
+        @test splice!(CircularVector([1, 2, 3]), [2, 3]) == [2, 3]
 
-      v = CircularVector([1, 2, 3, 4])
-      spliced = splice!(v, 2:3, [42, 43])
-      @test spliced == CircularVector([2, 3])
-      @test v == CircularVector([1, 42, 43, 4])
+        v = CircularVector([1, 2, 3, 4])
+        spliced = splice!(v, 2:3, [42, 43])
+        @test spliced == CircularVector([2, 3])
+        @test v == CircularVector([1, 42, 43, 4])
 
-      v = CircularVector([1, 2, 3, 4])
-      spliced = splice!(v, 3:2, [42, 43])
-      @test length(spliced) == 0
-      @test v == CircularVector([1, 2, 42, 43, 3, 4])
+        v = CircularVector([1, 2, 3, 4])
+        spliced = splice!(v, 3:2, [42, 43])
+        @test length(spliced) == 0
+        @test v == CircularVector([1, 2, 42, 43, 3, 4])
 
-      v1 = CircularVector([1, 2, 3, 4])
-      spliced1 = splice!(v1, 5:7, [42, 43])
-      v2 = CircularVector([1, 2, 3, 4])
-      spliced2 = splice!(v2, 1:3, [42, 43])
-      t = Vector([1, 2, 3, 4])
-      spliced3 = splice!(t, 1:3, [42, 43])
-      @test spliced3 == [1, 2, 3]
+        v1 = CircularVector([1, 2, 3, 4])
+        spliced1 = splice!(v1, 5:7, [42, 43])
+        v2 = CircularVector([1, 2, 3, 4])
+        spliced2 = splice!(v2, 1:3, [42, 43])
+        t = Vector([1, 2, 3, 4])
+        spliced3 = splice!(t, 1:3, [42, 43])
+        @test spliced3 == [1, 2, 3]
 
-      @test spliced1 == CircularVector([1, 2, 3])
-      @test spliced1 == spliced2
-      @test v1 == v2
-      @test v1 == t
+        @test spliced1 == CircularVector([1, 2, 3])
+        @test spliced1 == spliced2
+        @test v1 == v2
+        @test v1 == t
 
-      v = CircularVector([1, 2, 3, 4])
-      spliced = splice!(v, 5:4, [42, 43])
-      @test length(spliced) == 0
-      @test v == CircularVector([42, 43, 1, 2, 3, 4])
+        v = CircularVector([1, 2, 3, 4])
+        spliced = splice!(v, 5:4, [42, 43])
+        @test length(spliced) == 0
+        @test v == CircularVector([42, 43, 1, 2, 3, 4])
     end
 
     @testset "doubly circular" begin
-      a = CircularVector([1, 2, 3, 4, 5])
-      b = CircularVector(a)
+        a = CircularVector([1, 2, 3, 4, 5])
+        b = CircularVector(a)
 
-      @test all(a[i] == b[i] for i in -50:50)
+        @test all(a[i] == b[i] for i in -50:50)
     end
 
     @testset "type stability" begin
-      v3 = @inferred(map(x -> x+1, CircularArray([1, 2, 3, 4])))
-      @test v3 isa CircularVector{Int64}
-      @test v3 == CircularArray([2, 3, 4, 5])
-      @test similar(v3, Base.OneTo(4)) isa typeof(v3)
-      @test similar(typeof(v3), Base.OneTo(4)) isa typeof(v3)
-      @test similar(typeof(v3), 4) isa typeof(v3)
-      @test similar(typeof(v3), 4) isa typeof(v3)
+        v3 = @inferred(map(x -> x+1, CircularArray([1, 2, 3, 4])))
+        @test v3 isa CircularVector{Int64}
+        @test v3 == CircularArray([2, 3, 4, 5])
+        @test similar(v3, Base.OneTo(4)) isa typeof(v3)
+        @test similar(typeof(v3), Base.OneTo(4)) isa typeof(v3)
+        @test similar(typeof(v3), 4) isa typeof(v3)
+        @test similar(typeof(v3), 4) isa typeof(v3)
 
-      v4 = @inferred(CircularArray([1, 2, 3, 4]) .+ 1)
-      @test v4 isa CircularVector{Int64}
-      @test v4 == CircularArray([2, 3, 4, 5])
+        v4 = @inferred(CircularArray([1, 2, 3, 4]) .+ 1)
+        @test v4 isa CircularVector{Int64}
+        @test v4 == CircularArray([2, 3, 4, 5])
 
-      v5 = v4 .> 3
-      @test v5 isa CircularVector{Bool, BitVector}
-      @test v5 == CircularArray([0, 0, 1, 1])
+        v5 = v4 .> 3
+        @test v5 isa CircularVector{Bool, BitVector}
+        @test v5 == CircularArray([0, 0, 1, 1])
     end
 end
 
@@ -296,12 +335,12 @@ end
     @test a3 == CircularArray(5, (2, 3))
 
     @testset "doubly circular" begin
-      a = CircularMatrix(b_arr)
-      da = CircularMatrix(a)
+        a = CircularMatrix(b_arr)
+        da = CircularMatrix(a)
 
-      @test da isa CircularMatrix
-      @test all(a[i, j] == da[i, j] for i in -8:8, j in -8:8)
-      @test all(a[i] == da[i] for i in -50:50)
+        @test da isa CircularMatrix
+        @test all(a[i, j] == da[i, j] for i in -8:8, j in -8:8)
+        @test all(a[i] == da[i] for i in -50:50)
     end
 end
 
@@ -332,11 +371,11 @@ end
     @test_throws BoundsError c3[CartesianIndex(2,3)]
 
     @testset "doubly circular" begin
-      c = CircularArray(t3)
-      dc = CircularArray(c)
+        c = CircularArray(t3)
+        dc = CircularArray(c)
 
-      @test all(c[i, j, k] == dc[i, j, k] for i in -5:5, j in -5:5, k in -5:5)
-      @test all(c[i] == dc[i] for i in -50:50)
+        @test all(c[i, j, k] == dc[i, j, k] for i in -5:5, j in -5:5, k in -5:5)
+        @test all(c[i] == dc[i] for i in -50:50)
     end
 end
 
@@ -352,12 +391,12 @@ end
     @test a[i] == OffsetArray([4,5,1,2,3],-3)
 
     @testset "type stability" begin
-      @test @inferred(similar(a)) isa CircularVector
-      @test @inferred(similar(typeof(a), axes(a))) isa CircularVector
+        @test @inferred(similar(a)) isa CircularVector
+        @test @inferred(similar(typeof(a), axes(a))) isa CircularVector
 
-      b = CircularVector([1, 2, 3, 4, 5])
-      @test @inferred(similar(b, 3:5)) isa CircularVector
-      @test @inferred(similar(typeof(b), 3:5)) isa CircularVector
+        b = CircularVector([1, 2, 3, 4, 5])
+        @test @inferred(similar(b, 3:5)) isa CircularVector
+        @test @inferred(similar(typeof(b), 3:5)) isa CircularVector
     end
 
     circ_a = circshift(a,3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,375 +3,375 @@ using OffsetArrays
 using Test
 
 @testset "index style" begin
-  @test IndexStyle(CircularArray) == IndexCartesian()
-  @test IndexStyle(CircularVector) == IndexLinear()
+    @test IndexStyle(CircularArray) == IndexCartesian()
+    @test IndexStyle(CircularVector) == IndexLinear()
 end
 
 @testset "construction" begin
-  @testset "construction ($T)" for T = (Float64, Int)
-    data = rand(T,10)
-    arrays = [CircularVector(data), CircularVector{T}(data),
-      CircularArray(data), CircularArray{T}(data), CircularArray{T,1}(data)]
-    @test all(a == first(arrays) for a in arrays)
-    @test all(a isa CircularVector{T,Vector{T}} for a in arrays)
-  end
+    @testset "construction ($T)" for T = (Float64, Int)
+      data = rand(T,10)
+      arrays = [CircularVector(data), CircularVector{T}(data),
+              CircularArray(data), CircularArray{T}(data), CircularArray{T,1}(data)]
+      @test all(a == first(arrays) for a in arrays)
+      @test all(a isa CircularVector{T,Vector{T}} for a in arrays)
+    end
 
-  @testset "matrix construction" begin
-    data = zeros(Float64, 2, 2)
-    ref = CircularMatrix(data)
-    @test CircularArray{Float64, 2}(data) == ref
-    @test CircularMatrix{Float64}(data) == ref
-    @test CircularMatrix{Float64, Array{Float64, 2}}(data) == ref
-    @test CircularMatrix{Float64, Matrix{Float64}}(data) == ref
-  end
+    @testset "matrix construction" begin
+      data = zeros(Float64, 2, 2)
+      ref = CircularMatrix(data)
+      @test CircularArray{Float64, 2}(data) == ref
+      @test CircularMatrix{Float64}(data) == ref
+      @test CircularMatrix{Float64, Array{Float64, 2}}(data) == ref
+      @test CircularMatrix{Float64, Matrix{Float64}}(data) == ref
+    end
 end
 
 @testset "type stability" begin
-  @testset "type stability $(n)d" for n in 1:10
-    a = CircularArray(fill(1, ntuple(_->1, n)))
+    @testset "type stability $(n)d" for n in 1:10
+      a = CircularArray(fill(1, ntuple(_->1, n)))
 
-    @test @inferred(a[1]) isa Int64
-    @test @inferred(a[[1]]) isa CircularVector{Int64}
-    @test @inferred(a[[1]']) isa CircularArray{Int64,2}
-    @test @inferred(axes(a)) isa Tuple{Vararg{AbstractUnitRange}}
-    @test @inferred(similar(a)) isa typeof(a)
-    @test @inferred(similar(a, Float64, Int8.(size(a)))) isa CircularArray{Float64}
-    @test @inferred(similar(typeof(a), axes(a))) isa typeof(a)
-    @test @inferred(a[a]) isa typeof(a)
-  end
+      @test @inferred(a[1]) isa Int64
+      @test @inferred(a[[1]]) isa CircularVector{Int64}
+      @test @inferred(a[[1]']) isa CircularArray{Int64,2}
+      @test @inferred(axes(a)) isa Tuple{Vararg{AbstractUnitRange}}
+      @test @inferred(similar(a)) isa typeof(a)
+      @test @inferred(similar(a, Float64, Int8.(size(a)))) isa CircularArray{Float64}
+      @test @inferred(similar(typeof(a), axes(a))) isa typeof(a)
+      @test @inferred(a[a]) isa typeof(a)
+    end
 end
 
 @testset "display" begin
-  @testset "display $(n)d" for n in 1:3
-    data = rand(Int64, ntuple(_->3, n))
-    v1 = CircularArray(data)
-    io = IOBuffer()
-    io_compare = IOBuffer()
+    @testset "display $(n)d" for n in 1:3
+      data = rand(Int64, ntuple(_->3, n))
+      v1 = CircularArray(data)
+      io = IOBuffer()
+      io_compare = IOBuffer()
 
-    print(io, v1)
-    print(io_compare, data)
-    @test String(take!(io)) == String(take!(io_compare))
+      print(io, v1)
+      print(io_compare, data)
+      @test String(take!(io)) == String(take!(io_compare))
 
-    print(io, summary(v1))
-    print(io_compare, summary(data))
+      print(io, summary(v1))
+      print(io_compare, summary(data))
 
-    text = String(take!(io_compare))
-    text = replace(text, " Vector" => " CircularVector")
-    text = replace(text, " Matrix" => " CircularArray")
-    text = replace(text, " Array" => (n == 1 ? " CircularVector" : " CircularArray"))
-    text = replace(text, r"{.+}" => "(::$(string(typeof(data))))")
-    @test String(take!(io)) == text
-  end
+      text = String(take!(io_compare))
+      text = replace(text, " Vector" => " CircularVector")
+      text = replace(text, " Matrix" => " CircularArray")
+      text = replace(text, " Array" => (n == 1 ? " CircularVector" : " CircularArray"))
+      text = replace(text, r"{.+}" => "(::$(string(typeof(data))))")
+      @test String(take!(io)) == text
+    end
 end
 
 @testset "vector" begin
-  data = rand(Int64, 5)
-  v1 = CircularVector(data)
+    data = rand(Int64, 5)
+    v1 = CircularVector(data)
 
-  @test size(v1, 1) == 5
-  @test parent(v1) == data
-  @test typeof(v1) == CircularVector{Int64,Vector{Int64}}
-  @test isa(v1, CircularVector)
-  @test isa(v1, AbstractVector{Int})
-  @test !isa(v1, AbstractVector{String})
-  @test v1[2] == v1[2 + length(v1)]
+    @test size(v1, 1) == 5
+    @test parent(v1) == data
+    @test typeof(v1) == CircularVector{Int64,Vector{Int64}}
+    @test isa(v1, CircularVector)
+    @test isa(v1, AbstractVector{Int})
+    @test !isa(v1, AbstractVector{String})
+    @test v1[2] == v1[2 + length(v1)]
 
-  @test IndexStyle(v1) == IndexStyle(typeof(v1)) == IndexLinear()
-  @test v1[0] == data[end]
-  @test v1[-4:10] == [data; data; data]
-  @test v1[-3:1][-1] == data[end]
-  @test v1[[true,false,true,false,true]] == v1[[1,3,0]]
-  @test all(e in data for e in v1)
-  @test all(e in v1 for e in data)
+    @test IndexStyle(v1) == IndexStyle(typeof(v1)) == IndexLinear()
+    @test v1[0] == data[end]
+    @test v1[-4:10] == [data; data; data]
+    @test v1[-3:1][-1] == data[end]
+    @test v1[[true,false,true,false,true]] == v1[[1,3,0]]
+    @test all(e in data for e in v1)
+    @test all(e in v1 for e in data)
 
-  v1copy = copy(v1)
-  v1_2 = v1[2]
-  v1[2] = 0
-  v1[3] = 0
-  @test v1[2] == v1[3] == 0
-  @test v1copy[2] == v1_2
-  @test v1copy[7] == v1_2
-  @test_throws MethodError v1[2] = "Hello"
-
-  v2 = CircularVector("abcde", 5)
-
-  @test prod(v2) == "abcde"^5
-
-  @testset "empty/empty!" begin
-    v1 = CircularVector([1,2,3])
-    @test empty(v1) isa CircularVector{Int64}
-    @test empty(v1, Float64) isa CircularVector{Float64}
-    v1 == CircularVector([])
-    # `isempty` can be used to implement `size` method.
-    @test isempty(empty(v1))
+    v1copy = copy(v1)
+    v1_2 = v1[2]
+    v1[2] = 0
+    v1[3] = 0
+    @test v1[2] == v1[3] == 0
+    @test v1copy[2] == v1_2
+    @test v1copy[7] == v1_2
+    @test_throws MethodError v1[2] = "Hello"
 
     v2 = CircularVector("abcde", 5)
-    @test empty!(v2) isa CircularVector{String}
-    @test isempty(v2)
-  end
 
-  @testset "resize!" begin
-    @test_throws ArgumentError("new length must be ≥ 0") resize!(CircularVector([]), -2)
-    v = CircularVector([1,2,3,4,5,6,7])
-    resize!(v, 3)
-    @test length(v) == 3
+    @test prod(v2) == "abcde"^5
 
-    # ensure defining `resize!` induces `push!` and `append!` methods
-    @testset "push!" begin
-      v = CircularVector([1,2,3])
-      push!(v, 42)
-      @test v == CircularVector([1,2,3,42])
-      push!(v, -9, -99, -999)
-      @test v == CircularVector([1,2,3,42, -9, -99, -999])
-    end
-
-    @testset "append!" begin
+    @testset "empty/empty!" begin
       v1 = CircularVector([1,2,3])
-      append!(v1, [-9, -99, -999])
-      @test v1 == CircularVector([1,2,3, -9, -99, -999])
+      @test empty(v1) isa CircularVector{Int64}
+      @test empty(v1, Float64) isa CircularVector{Float64}
+      v1 == CircularVector([])
+      # `isempty` can be used to implement `size` method.
+      @test isempty(empty(v1))
 
-      v2 = CircularVector([1,2,3])
-      append!(v2, CircularVector([-1,-2]))
-      @test v2 == CircularVector([1,2,3,-1,-2])
-
-      v3 = CircularVector([1,2,3])
-      append!(v3, [4, 5], [6])
-      @test v3 == CircularVector([1,2,3,4,5,6])
-
-      v4 = CircularVector([1,2,3])
-      o4 = OffsetVector([-1,-2,-3], -2:0)
-      append!(v4, o4)
-      @test v4 == CircularVector([1,2,3,-1,-2,-3])
-
-      v5 = CircularVector([1,2,3])
-      o5 = OffsetVector([-1,-2,-3], -2:0)
-      append!(v5, o5, -4)
-      @test v5 == CircularVector([1,2,3,-1,-2,-3,-4])
+      v2 = CircularVector("abcde", 5)
+      @test empty!(v2) isa CircularVector{String}
+      @test isempty(v2)
     end
-  end
 
-  @testset "pop!" begin
-    v1 = CircularVector([1,2,3,42])
-    pop!(v1) == 42
-    @test v1 == CircularVector([1,2,3])
+    @testset "resize!" begin
+      @test_throws ArgumentError("new length must be ≥ 0") resize!(CircularVector([]), -2)
+      v = CircularVector([1,2,3,4,5,6,7])
+      resize!(v, 3)
+      @test length(v) == 3
 
-    v2 = CircularVector([1])
-    pop!(v2) == 1
-    @test v2 == CircularVector([])
-    @test isempty(v2)
-    @test_throws ArgumentError("array must be non-empty") pop!(v2)
-  end
+      # ensure defining `resize!` induces `push!` and `append!` methods
+      @testset "push!" begin
+        v = CircularVector([1,2,3])
+        push!(v, 42)
+        @test v == CircularVector([1,2,3,42])
+        push!(v, -9, -99, -999)
+        @test v == CircularVector([1,2,3,42, -9, -99, -999])
+      end
 
-  @testset "sizehint!" begin
-    v = CircularVector([1,2,3,4,5,6,7])
-    resize!(v, 1)
-    sizehint!(v, 1)
-    @test length(v) == 1
-  end
+      @testset "append!" begin
+        v1 = CircularVector([1,2,3])
+        append!(v1, [-9, -99, -999])
+        @test v1 == CircularVector([1,2,3, -9, -99, -999])
 
-  @testset "deleteat!" begin
-    @test deleteat!(CircularVector([1, 2, 3]), 2) == CircularVector([1, 3])
-    @test deleteat!(CircularVector([1, 2, 3]), 5) == CircularVector([1, 3])
-    @test deleteat!(CircularVector([1, 2, 3]), 4) == CircularVector([2, 3])
-    @test deleteat!(CircularVector([1, 2, 3]), 0) == CircularVector([1, 2])
-    @test deleteat!(CircularVector([1, 2, 3, 4]), 1:5:10) == CircularVector([3, 4])
-    @test deleteat!(CircularVector([1, 2, 3, 4]), [1, 5]) == CircularVector([2, 3, 4])
-    @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5)) == CircularVector([2, 3, 4])
-    @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 6)) == CircularVector([3, 4])
-    @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 3, 5)) == CircularVector([2, 4])
-    @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5, 7)) == CircularVector([2, 4])
-  end
+        v2 = CircularVector([1,2,3])
+        append!(v2, CircularVector([-1,-2]))
+        @test v2 == CircularVector([1,2,3,-1,-2])
 
-  @testset "insert!" begin
-    @test insert!(CircularVector([1, 2, 3]), 2, 4) == CircularVector([1, 4, 2, 3])
-    @test insert!(CircularVector([1, 2, 3]), 5, 4) == CircularVector([1, 4, 2, 3])
-    @test insert!(CircularVector([1, 2, 3]), 4, 4) == CircularVector([4, 1, 2, 3])
-    @test insert!(CircularVector([1, 2, 3]), 0, 4) == CircularVector([1, 2, 4, 3])
-  end
-  @testset "splice!" begin
-    @test splice!(CircularVector([1, 2, 3]), 2) == 2
-    @test splice!(CircularVector([1, 2, 3]), 5) == 2
-    @test splice!(CircularVector([1, 2, 3]), 4) == 1
-    @test splice!(CircularVector([1, 2, 3]), 0) == 3
-    @test splice!(CircularVector([1, 2, 3]), [2, 3]) == [2, 3]
+        v3 = CircularVector([1,2,3])
+        append!(v3, [4, 5], [6])
+        @test v3 == CircularVector([1,2,3,4,5,6])
 
-    v = CircularVector([1, 2, 3, 4])
-    spliced = splice!(v, 2:3, [42, 43])
-    @test spliced == CircularVector([2, 3])
-    @test v == CircularVector([1, 42, 43, 4])
+        v4 = CircularVector([1,2,3])
+        o4 = OffsetVector([-1,-2,-3], -2:0)
+        append!(v4, o4)
+        @test v4 == CircularVector([1,2,3,-1,-2,-3])
 
-    v = CircularVector([1, 2, 3, 4])
-    spliced = splice!(v, 3:2, [42, 43])
-    @test length(spliced) == 0
-    @test v == CircularVector([1, 2, 42, 43, 3, 4])
+        v5 = CircularVector([1,2,3])
+        o5 = OffsetVector([-1,-2,-3], -2:0)
+        append!(v5, o5, -4)
+        @test v5 == CircularVector([1,2,3,-1,-2,-3,-4])
+      end
+    end
 
-    v1 = CircularVector([1, 2, 3, 4])
-    spliced1 = splice!(v1, 5:7, [42, 43])
-    v2 = CircularVector([1, 2, 3, 4])
-    spliced2 = splice!(v2, 1:3, [42, 43])
-    t = Vector([1, 2, 3, 4])
-    spliced3 = splice!(t, 1:3, [42, 43])
-    @test spliced3 == [1, 2, 3]
+    @testset "pop!" begin
+      v1 = CircularVector([1,2,3,42])
+      pop!(v1) == 42
+      @test v1 == CircularVector([1,2,3])
 
-    @test spliced1 == CircularVector([1, 2, 3])
-    @test spliced1 == spliced2
-    @test v1 == v2
-    @test v1 == t
+      v2 = CircularVector([1])
+      pop!(v2) == 1
+      @test v2 == CircularVector([])
+      @test isempty(v2)
+      @test_throws ArgumentError("array must be non-empty") pop!(v2)
+    end
 
-    v = CircularVector([1, 2, 3, 4])
-    spliced = splice!(v, 5:4, [42, 43])
-    @test length(spliced) == 0
-    @test v == CircularVector([42, 43, 1, 2, 3, 4])
-  end
+    @testset "sizehint!" begin
+      v = CircularVector([1,2,3,4,5,6,7])
+      resize!(v, 1)
+      sizehint!(v, 1)
+      @test length(v) == 1
+    end
 
-  @testset "doubly circular" begin
-    a = CircularVector([1, 2, 3, 4, 5])
-    b = CircularVector(a)
+    @testset "deleteat!" begin
+      @test deleteat!(CircularVector([1, 2, 3]), 2) == CircularVector([1, 3])
+      @test deleteat!(CircularVector([1, 2, 3]), 5) == CircularVector([1, 3])
+      @test deleteat!(CircularVector([1, 2, 3]), 4) == CircularVector([2, 3])
+      @test deleteat!(CircularVector([1, 2, 3]), 0) == CircularVector([1, 2])
+      @test deleteat!(CircularVector([1, 2, 3, 4]), 1:5:10) == CircularVector([3, 4])
+      @test deleteat!(CircularVector([1, 2, 3, 4]), [1, 5]) == CircularVector([2, 3, 4])
+      @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5)) == CircularVector([2, 3, 4])
+      @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 6)) == CircularVector([3, 4])
+      @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 3, 5)) == CircularVector([2, 4])
+      @test deleteat!(CircularVector([1, 2, 3, 4]), (1, 5, 7)) == CircularVector([2, 4])
+    end
 
-    @test all(a[i] == b[i] for i in -50:50)
-  end
+    @testset "insert!" begin
+      @test insert!(CircularVector([1, 2, 3]), 2, 4) == CircularVector([1, 4, 2, 3])
+      @test insert!(CircularVector([1, 2, 3]), 5, 4) == CircularVector([1, 4, 2, 3])
+      @test insert!(CircularVector([1, 2, 3]), 4, 4) == CircularVector([4, 1, 2, 3])
+      @test insert!(CircularVector([1, 2, 3]), 0, 4) == CircularVector([1, 2, 4, 3])
+    end
+    @testset "splice!" begin
+      @test splice!(CircularVector([1, 2, 3]), 2) == 2
+      @test splice!(CircularVector([1, 2, 3]), 5) == 2
+      @test splice!(CircularVector([1, 2, 3]), 4) == 1
+      @test splice!(CircularVector([1, 2, 3]), 0) == 3
+      @test splice!(CircularVector([1, 2, 3]), [2, 3]) == [2, 3]
 
-  @testset "type stability" begin
-    v3 = @inferred(map(x -> x+1, CircularArray([1, 2, 3, 4])))
-    @test v3 isa CircularVector{Int64}
-    @test v3 == CircularArray([2, 3, 4, 5])
-    @test similar(v3, Base.OneTo(4)) isa typeof(v3)
-    @test similar(typeof(v3), Base.OneTo(4)) isa typeof(v3)
-    @test similar(typeof(v3), 4) isa typeof(v3)
-    @test similar(typeof(v3), 4) isa typeof(v3)
+      v = CircularVector([1, 2, 3, 4])
+      spliced = splice!(v, 2:3, [42, 43])
+      @test spliced == CircularVector([2, 3])
+      @test v == CircularVector([1, 42, 43, 4])
 
-    v4 = @inferred(CircularArray([1, 2, 3, 4]) .+ 1)
-    @test v4 isa CircularVector{Int64}
-    @test v4 == CircularArray([2, 3, 4, 5])
+      v = CircularVector([1, 2, 3, 4])
+      spliced = splice!(v, 3:2, [42, 43])
+      @test length(spliced) == 0
+      @test v == CircularVector([1, 2, 42, 43, 3, 4])
 
-    v5 = v4 .> 3
-    @test v5 isa CircularVector{Bool, BitVector}
-    @test v5 == CircularArray([0, 0, 1, 1])
-  end
+      v1 = CircularVector([1, 2, 3, 4])
+      spliced1 = splice!(v1, 5:7, [42, 43])
+      v2 = CircularVector([1, 2, 3, 4])
+      spliced2 = splice!(v2, 1:3, [42, 43])
+      t = Vector([1, 2, 3, 4])
+      spliced3 = splice!(t, 1:3, [42, 43])
+      @test spliced3 == [1, 2, 3]
+
+      @test spliced1 == CircularVector([1, 2, 3])
+      @test spliced1 == spliced2
+      @test v1 == v2
+      @test v1 == t
+
+      v = CircularVector([1, 2, 3, 4])
+      spliced = splice!(v, 5:4, [42, 43])
+      @test length(spliced) == 0
+      @test v == CircularVector([42, 43, 1, 2, 3, 4])
+    end
+
+    @testset "doubly circular" begin
+      a = CircularVector([1, 2, 3, 4, 5])
+      b = CircularVector(a)
+
+      @test all(a[i] == b[i] for i in -50:50)
+    end
+
+    @testset "type stability" begin
+      v3 = @inferred(map(x -> x+1, CircularArray([1, 2, 3, 4])))
+      @test v3 isa CircularVector{Int64}
+      @test v3 == CircularArray([2, 3, 4, 5])
+      @test similar(v3, Base.OneTo(4)) isa typeof(v3)
+      @test similar(typeof(v3), Base.OneTo(4)) isa typeof(v3)
+      @test similar(typeof(v3), 4) isa typeof(v3)
+      @test similar(typeof(v3), 4) isa typeof(v3)
+
+      v4 = @inferred(CircularArray([1, 2, 3, 4]) .+ 1)
+      @test v4 isa CircularVector{Int64}
+      @test v4 == CircularArray([2, 3, 4, 5])
+
+      v5 = v4 .> 3
+      @test v5 isa CircularVector{Bool, BitVector}
+      @test v5 == CircularArray([0, 0, 1, 1])
+    end
 end
 
 @testset "matrix" begin
-  b_arr = [2 4 6 8; 10 12 14 16; 18 20 22 24]
-  a1 = CircularMatrix(b_arr)
-  @test size(a1) == (3, 4)
-  @test parent(a1) == b_arr
+    b_arr = [2 4 6 8; 10 12 14 16; 18 20 22 24]
+    a1 = CircularMatrix(b_arr)
+    @test size(a1) == (3, 4)
+    @test parent(a1) == b_arr
 
-  @test a1[2, 3] == 14
-  @test a1[2, Int32(3)] == 14
-  a1[2, 3] = 17
-  @test a1[2, 3] == 17
-  @test a1[-1, 7] == 17
-  @test a1[CartesianIndex(-1, 7)] == 17
-  @test a1[-1:5, 4:10][1, 4] == 17
-  @test a1[:, -1:-1][2, 1] == 17
-  a1[CartesianIndex(-2, 7)] = 99
-  @test a1[1, 3] == 99
+    @test a1[2, 3] == 14
+    @test a1[2, Int32(3)] == 14
+    a1[2, 3] = 17
+    @test a1[2, 3] == 17
+    @test a1[-1, 7] == 17
+    @test a1[CartesianIndex(-1, 7)] == 17
+    @test a1[-1:5, 4:10][1, 4] == 17
+    @test a1[:, -1:-1][2, 1] == 17
+    a1[CartesianIndex(-2, 7)] = 99
+    @test a1[1, 3] == 99
 
-  a1[18] = 9
-  @test a1[18] == a1[-6] == a1[6] == a1[3,2] == a1[0,6] == b_arr[3,2] == b_arr[6] == 9
+    a1[18] = 9
+    @test a1[18] == a1[-6] == a1[6] == a1[3,2] == a1[0,6] == b_arr[3,2] == b_arr[6] == 9
 
-  @test IndexStyle(a1) == IndexStyle(typeof(a1)) == IndexCartesian()
-  @test a1[3] == a1[3,1]
-  @test a1[Int32(4)] == a1[1,2]
-  @test a1[-1] == a1[length(a1)-1]
+    @test IndexStyle(a1) == IndexStyle(typeof(a1)) == IndexCartesian()
+    @test a1[3] == a1[3,1]
+    @test a1[Int32(4)] == a1[1,2]
+    @test a1[-1] == a1[length(a1)-1]
 
-  @test a1[2, 3, 1] == 17 # trailing index
-  @test a1[2, 3, 99] == 17
-  @test a1[2, 3, :] == [17]
+    @test a1[2, 3, 1] == 17 # trailing index
+    @test a1[2, 3, 99] == 17
+    @test a1[2, 3, :] == [17]
 
-  @test !isa(a1, CircularVector)
-  @test !isa(a1, AbstractVector)
-  @test isa(a1, AbstractMatrix)
-  @test isa(a1, AbstractArray)
+    @test !isa(a1, CircularVector)
+    @test !isa(a1, AbstractVector)
+    @test isa(a1, AbstractMatrix)
+    @test isa(a1, AbstractArray)
 
-  @test size(reshape(a1, (2, 2, 3))) == (2, 2, 3)
+    @test size(reshape(a1, (2, 2, 3))) == (2, 2, 3)
 
-  a2 = CircularMatrix(4, (2, 3))
-  @test isa(a2, CircularMatrix{Int})
-  @test isa(a2, CircularArray{Int, 2})
+    a2 = CircularMatrix(4, (2, 3))
+    @test isa(a2, CircularMatrix{Int})
+    @test isa(a2, CircularArray{Int, 2})
 
-  a3 = @inferred(a2 .+ 1)
-  @test a3 isa CircularMatrix{Int64}
-  @test a3 isa CircularArray{Int64, 2}
-  @test a3 == CircularArray(5, (2, 3))
+    a3 = @inferred(a2 .+ 1)
+    @test a3 isa CircularMatrix{Int64}
+    @test a3 isa CircularArray{Int64, 2}
+    @test a3 == CircularArray(5, (2, 3))
 
-  @testset "doubly circular" begin
-    a = CircularMatrix(b_arr)
-    da = CircularMatrix(a)
+    @testset "doubly circular" begin
+      a = CircularMatrix(b_arr)
+      da = CircularMatrix(a)
 
-    @test da isa CircularMatrix
-    @test all(a[i, j] == da[i, j] for i in -8:8, j in -8:8)
-    @test all(a[i] == da[i] for i in -50:50)
-  end
+      @test da isa CircularMatrix
+      @test all(a[i, j] == da[i, j] for i in -8:8, j in -8:8)
+      @test all(a[i] == da[i] for i in -50:50)
+    end
 end
 
 @testset "3-array" begin
-  t3 = collect(reshape('a':'x', 2,3,4))
-  c3 = CircularArray(t3)
+    t3 = collect(reshape('a':'x', 2,3,4))
+    c3 = CircularArray(t3)
 
-  @test parent(c3) == t3
+    @test parent(c3) == t3
 
-  @test c3[1,3,3] == c3[3,3,3] == c3[3,3,7] == c3[3,3,7,1]
+    @test c3[1,3,3] == c3[3,3,3] == c3[3,3,7] == c3[3,3,7,1]
 
-  c3[3,3,7] = 'Z'
-  @test t3[1,3,3] == 'Z'
+    c3[3,3,7] = 'Z'
+    @test t3[1,3,3] == 'Z'
 
-  @test c3[3, CartesianIndex(3,7)] == 'Z'
-  c3[Int32(3), CartesianIndex(3,7)] = 'ζ'
-  @test t3[1,3,3] == 'ζ'
+    @test c3[3, CartesianIndex(3,7)] == 'Z'
+    c3[Int32(3), CartesianIndex(3,7)] = 'ζ'
+    @test t3[1,3,3] == 'ζ'
 
-  c3[34] = 'J'
-  @test c3[34] == c3[-38] == c3[10] == c3[2,2,2] == c3[4,5,6] == t3[2,2,2] == t3[10] == 'J'
+    c3[34] = 'J'
+    @test c3[34] == c3[-38] == c3[10] == c3[2,2,2] == c3[4,5,6] == t3[2,2,2] == t3[10] == 'J'
 
-  @test vec(c3[:, [CartesianIndex()], 1, 5]) == vec(t3[:, 1, 1])
+    @test vec(c3[:, [CartesianIndex()], 1, 5]) == vec(t3[:, 1, 1])
 
-  @test IndexStyle(c3) == IndexStyle(typeof(c3)) == IndexCartesian()
-  @test c3[-1] == t3[length(t3)-1]
+    @test IndexStyle(c3) == IndexStyle(typeof(c3)) == IndexCartesian()
+    @test c3[-1] == t3[length(t3)-1]
 
-  @test_throws BoundsError c3[2,3] # too few indices
-  @test_throws BoundsError c3[CartesianIndex(2,3)]
+    @test_throws BoundsError c3[2,3] # too few indices
+    @test_throws BoundsError c3[CartesianIndex(2,3)]
 
-  @testset "doubly circular" begin
-    c = CircularArray(t3)
-    dc = CircularArray(c)
+    @testset "doubly circular" begin
+      c = CircularArray(t3)
+      dc = CircularArray(c)
 
-    @test all(c[i, j, k] == dc[i, j, k] for i in -5:5, j in -5:5, k in -5:5)
-    @test all(c[i] == dc[i] for i in -50:50)
-  end
+      @test all(c[i, j, k] == dc[i, j, k] for i in -5:5, j in -5:5, k in -5:5)
+      @test all(c[i] == dc[i] for i in -50:50)
+    end
 end
 
 @testset "offset indices" begin
-  i = OffsetArray(1:5,-3)
-  a = CircularArray(i)
-  @test axes(a) == axes(i)
-  @test a[1] == 4
-  @test a[10] == a[-10] == a[0] == 3
-  @test a[-2:7] == [1:5; 1:5]
-  @test a[0:9] == [3:5; 1:5; 1:2]
-  @test a[1:10][-10] == 3
-  @test a[i] == OffsetArray([4,5,1,2,3],-3)
+    i = OffsetArray(1:5,-3)
+    a = CircularArray(i)
+    @test axes(a) == axes(i)
+    @test a[1] == 4
+    @test a[10] == a[-10] == a[0] == 3
+    @test a[-2:7] == [1:5; 1:5]
+    @test a[0:9] == [3:5; 1:5; 1:2]
+    @test a[1:10][-10] == 3
+    @test a[i] == OffsetArray([4,5,1,2,3],-3)
 
-  @testset "type stability" begin
-    @test @inferred(similar(a)) isa CircularVector
-    @test @inferred(similar(typeof(a), axes(a))) isa CircularVector
+    @testset "type stability" begin
+      @test @inferred(similar(a)) isa CircularVector
+      @test @inferred(similar(typeof(a), axes(a))) isa CircularVector
 
-    b = CircularVector([1, 2, 3, 4, 5])
-    @test @inferred(similar(b, 3:5)) isa CircularVector
-    @test @inferred(similar(typeof(b), 3:5)) isa CircularVector
-  end
+      b = CircularVector([1, 2, 3, 4, 5])
+      @test @inferred(similar(b, 3:5)) isa CircularVector
+      @test @inferred(similar(typeof(b), 3:5)) isa CircularVector
+    end
 
-  circ_a = circshift(a,3)
-  @test axes(circ_a) == axes(a)
-  @test circ_a[1:5] == 1:5
+    circ_a = circshift(a,3)
+    @test axes(circ_a) == axes(a)
+    @test circ_a[1:5] == 1:5
 
-  j = OffsetArray([true,false,true],1)
-  @test a[j] == [5,2]
+    j = OffsetArray([true,false,true],1)
+    @test a[j] == [5,2]
 
-  data = reshape(1:9,3,3)
-  a = CircularArray(OffsetArray(data,-1,-1))
-  @test collect(a) == data
-  @test all(a[x,y] == data[mod1(x+1,3),mod1(y+1,3)] for x=-10:10, y=-10:10)
-  @test a[i,1] == CircularArray(OffsetArray([5,6,4,5,6],-2:2))
-  @test a[CartesianIndex.(i,i)] == CircularArray(OffsetArray([5,9,1,5,9],-2:2))
-  @test a[a .> 4] == 5:9
+    data = reshape(1:9,3,3)
+    a = CircularArray(OffsetArray(data,-1,-1))
+    @test collect(a) == data
+    @test all(a[x,y] == data[mod1(x+1,3),mod1(y+1,3)] for x=-10:10, y=-10:10)
+    @test a[i,1] == CircularArray(OffsetArray([5,6,4,5,6],-2:2))
+    @test a[CartesianIndex.(i,i)] == CircularArray(OffsetArray([5,9,1,5,9],-2:2))
+    @test a[a .> 4] == 5:9
 end


### PR DESCRIPTION
Hello, here's a working implementation of `splice!` for `CircularVectors`. 

The `AbstractUnitRange` method took reimplementing of Base.splice! internals. This is because simply putting in the modular range (`mod(first):mod(last)`  causes issues when first > last and first is length of the array+1. (in plain language, trying to splice a vector between the last and first elements).  Inputting the modular range will delete the entire array. Re-implementing, as I did, places the `ins` before the first element.

Maybe you have some clever simplification, but this was what I could figure out.